### PR TITLE
fix: Use `i18next`'s hook to translate localized content

### DIFF
--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/src/components/Form/constants/FormTable.js
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/src/components/Form/constants/FormTable.js
@@ -20,7 +20,7 @@ import SelectFormForDownload from "../FileUpload/SelectFormForDownload";
 import LoadingOverlay from "react-loading-overlay";
 import { STAFF_DESIGNER } from "../../../constants/constants";
 import { getBundle } from "../../../apiManager/services/bundleServices";
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 import { TYPE_BUNDLE } from "../../../constants/applicationConstants";
 
 function FormTable() {
@@ -43,6 +43,7 @@ function FormTable() {
   const [search, setSearch] = useState(searchText || "");
   const [bundleData, setBundleData] = useState([]);
   const [selectedRow, setSelectedRow] = useState(null);
+  const { t } = useTranslation();
 
   const pageOptions = [
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Localized content was wrapped with i18next's `t` function directly instead of its React hook. This PR removes the former and replaces it with the translation function provided by the `useTranslation` hook in `react-i18next`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've previewed the changes on my local environment:

![image](https://github.com/bcgov/nr-epd-digital-services/assets/149617222/e7f5e34c-772d-473d-8e3e-c0018e9b3e5f)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
