### PR TITLE
fix: error message coming from the backend

### DIFF
--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/src/components/Form/Item/View.js
@@ -1,0 +1,539 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { push } from "connected-react-router";
+import { connect, useDispatch, useSelector } from "react-redux";
+import {
+  selectRoot,
+  resetSubmissions,
+  saveSubmission,
+  Form,
+  selectError,
+  Errors,
+  getForm,
+  Formio,
+} from "react-formio";
+import { useTranslation, Translation } from "react-i18next";
+import isEqual from "lodash/isEqual";
+
+import Loading from "../../../containers/Loading";
+import {
+  getProcessReq,
+  getDraftReqFormat,
+} from "../../../apiManager/services/bpmServices";
+import { formio_resourceBundles } from "../../../resourceBundles/formio_resourceBundles";
+import {
+  setFormFailureErrorData,
+  setFormRequestData,
+  setFormSubmissionError,
+  setFormSubmissionLoading,
+  setFormSuccessData,
+  setMaintainBPMFormPagination,
+} from "../../../actions/formActions";
+import SubmissionError from "../../../containers/SubmissionError";
+import { publicApplicationStatus } from "../../../apiManager/services/applicationServices";
+import LoadingOverlay from "react-loading-overlay";
+import { CUSTOM_EVENT_TYPE } from "../../ServiceFlow/constants/customEventTypes";
+import { toast } from "react-toastify";
+import { setFormSubmitted } from "../../../actions/formActions";
+import { fetchFormByAlias } from "../../../apiManager/services/bpmFormServices";
+import { checkIsObjectId } from "../../../apiManager/services/formatterService";
+import {
+  draftCreate,
+  draftUpdate,
+  publicDraftCreate,
+  publicDraftUpdate,
+} from "../../../apiManager/services/draftService";
+import { setPublicStatusLoading } from "../../../actions/applicationActions";
+import { postCustomSubmission } from "../../../apiManager/services/FormServices";
+import {
+  CUSTOM_SUBMISSION_URL,
+  CUSTOM_SUBMISSION_ENABLE,
+  MULTITENANCY_ENABLED,
+  DRAFT_ENABLED,
+  DRAFT_POLLING_RATE,
+} from "../../../constants/constants";
+import useInterval from "../../../customHooks/useInterval";
+import selectApplicationCreateAPI from "./apiSelectHelper";
+import {
+  getApplicationCount,
+  getFormProcesses,
+} from "../../../apiManager/services/processServices";
+import { setFormStatusLoading } from "../../../actions/processActions";
+import SavingLoading from "../../Loading/SavingLoading";
+//import NotFound from "../../NotFound/";
+import { renderPage } from "../../../helper/helper";
+
+const View = React.memo((props) => {
+  const [formStatus, setFormStatus] = React.useState("");
+  const { t } = useTranslation();
+  const lang = useSelector((state) => state.user.lang);
+  const pubSub = useSelector((state) => state.pubSub);
+  const formStatusLoading = useSelector(
+    (state) => state.process?.formStatusLoading
+  );
+  const isFormSubmissionLoading = useSelector(
+    (state) => state.formDelete.isFormSubmissionLoading
+  );
+  const isPublicStatusLoading = useSelector(
+    (state) => state.applications.isPublicStatusLoading
+  );
+
+  const isFormSubmitted = useSelector(
+    (state) => state.formDelete.formSubmitted
+  );
+  const publicFormStatus = useSelector(
+    (state) => state.formDelete.publicFormStatus
+  );
+  const draftSubmissionId = useSelector(
+    (state) => state.draft.draftSubmission?.id
+  );
+  // Holds the latest data saved by the server
+  const processLoadError = useSelector((state) => state.process?.processLoadError);
+  const lastUpdatedDraft = useSelector((state) => state.draft.lastUpdated);
+  const isPublic = !props.isAuthenticated;
+  const tenantKey = useSelector((state) => state.tenants?.tenantId);
+  const redirectUrl = MULTITENANCY_ENABLED ? `/tenant/${tenantKey}/` : "/";
+  /**
+   * `draftData` is used for keeping the uptodate form entry,
+   * this will get updated on every change the form is having.
+   */
+  const [draftData, setDraftData] = useState({});
+  const draftRef = useRef();
+  const [isDraftCreated, setIsDraftCreated] = useState(false);
+
+  const { formId } = useParams();
+  const [validFormId, setValidFormId] = useState(undefined);
+
+  const [showPublicForm, setShowPublicForm] = useState("checking");
+  const [poll, setPoll] = useState(DRAFT_ENABLED);
+  const exitType = useRef("UNMOUNT");
+  const [draftSaved, setDraftSaved] = useState(false);
+  const [notified, setNotified] = useState(false);
+  const {
+    isAuthenticated,
+    submission,
+    hideComponents,
+    onSubmit,
+    onCustomEvent,
+    errors,
+    options,
+    form: { form, isActive, url, error },
+  } = props;
+
+  const [isValidResource, setIsValidResource] = useState(false);
+
+  const dispatch = useDispatch();
+  /*
+  Selecting which endpoint to use based on authentication status,
+  public endpoint or authenticated endpoint.
+  */
+  const draftCreateMethod = isAuthenticated ? draftCreate : publicDraftCreate;
+  const draftUpdateMethod = isAuthenticated ? draftUpdate : publicDraftUpdate;
+
+  const getPublicForm = useCallback(
+    (form_id, isObjectId, formObj) => {
+      dispatch(setPublicStatusLoading(true));
+      dispatch(
+        publicApplicationStatus(form_id, (err) => {
+          dispatch(setPublicStatusLoading(false));
+          if (!err) {
+            if (isPublic) {
+              if (isObjectId) {
+                dispatch(getForm("form", form_id));
+                dispatch(setFormStatusLoading(false));
+              } else {
+                dispatch(
+                  setFormRequestData(
+                    "form",
+                    form_id,
+                    `${Formio.getProjectUrl()}/form/${form_id}`
+                  )
+                );
+                dispatch(setFormSuccessData("form", formObj));
+                dispatch(setFormStatusLoading(false));
+              }
+            }
+          }
+        })
+      );
+    },
+    [dispatch, isPublic]
+  );
+  const getFormData = useCallback(() => {
+    const isObjectId = checkIsObjectId(formId);
+    if (isObjectId) {
+      getPublicForm(formId, isObjectId);
+      setValidFormId(formId);
+    } else {
+      dispatch(
+        fetchFormByAlias(formId, async (err, formObj) => {
+          if (!err) {
+            const form_id = formObj._id;
+            getPublicForm(form_id, isObjectId, formObj);
+            setValidFormId(form_id);
+          } else {
+            dispatch(setFormFailureErrorData("form", err));
+          }
+        })
+      );
+    }
+  }, [formId, dispatch, getPublicForm]);
+  /**
+   * Compares the current form data and last saved data
+   * Draft is updated only if the form is updated from the last saved form data.
+   */
+  const saveDraft = (payload, exitType = exitType) => {
+    if (exitType === "SUBMIT") return;
+    let dataChanged = !isEqual(payload.data, lastUpdatedDraft.data);
+    if (draftSubmissionId && isDraftCreated) {
+      if (dataChanged) {
+        setDraftSaved(false);
+        dispatch(
+          draftUpdateMethod(payload, draftSubmissionId, (err) => {
+            if (exitType === "UNMOUNT" && !err && isAuthenticated) {
+              toast.success(t("Submission saved to draft."));
+            }
+            if (!err) {
+              setDraftSaved(true);
+            } else {
+              setDraftSaved(false);
+            }
+          })
+        );
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (form._id && !error) setIsValidResource(true);
+    return () => setIsValidResource(false);
+  }, [error, form._id]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setNotified(true);
+    }, 5000);
+  }, []);
+
+  useEffect(() => {
+    if (isDraftCreated) {
+      setDraftSaved(true);
+    }
+  }, [isDraftCreated]);
+
+  /**
+   * Will create a draft application when the form is selected for entry.
+   */
+  useEffect(() => {
+    if (
+      validFormId &&
+      DRAFT_ENABLED &&
+      isValidResource &&
+      ((isAuthenticated && formStatus === "active") ||
+        (!isAuthenticated && publicFormStatus?.status == "active"))
+    ) {
+      let payload = getDraftReqFormat(validFormId, draftData?.data);
+      dispatch(draftCreateMethod(payload, setIsDraftCreated));
+    }
+  }, [validFormId, formStatus, publicFormStatus, isValidResource]);
+
+  /**
+   * We will repeatedly update the current state to draft table
+   * on purticular interval
+   */
+  useInterval(
+    () => {
+      let payload = getDraftReqFormat(validFormId, { ...draftData?.data });
+      saveDraft(payload);
+    },
+    poll ? DRAFT_POLLING_RATE : null
+  );
+
+  /**
+   * Save the current state when the component unmounts.
+   * Save the data before submission to handle submission failure.
+   */
+  useEffect(() => {
+    return () => {
+      let payload = getDraftReqFormat(validFormId, draftRef.current?.data);
+      if (poll) saveDraft(payload, exitType.current);
+    };
+  }, [validFormId, draftSubmissionId, isDraftCreated, poll, exitType.current]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      dispatch(setFormStatusLoading(true));
+      dispatch(
+        getFormProcesses(formId, (err, data) => {
+          if (!err) {
+            dispatch(getApplicationCount(data.id));
+            setFormStatus(data.status);
+            dispatch(setFormStatusLoading(false));
+          }else{
+            dispatch(setFormStatusLoading(false));
+          }
+        })
+      );
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (isPublic) {
+      getFormData();
+    } else {
+      setValidFormId(formId);
+    }
+  }, [isPublic, dispatch, getFormData]);
+
+  useEffect(() => {
+    if (publicFormStatus) {
+      if (
+        publicFormStatus.anonymous === true &&
+        publicFormStatus.status === "active"
+      ) {
+        setShowPublicForm(true);
+      } else {
+        setShowPublicForm(false);
+      }
+    }
+  }, [publicFormStatus]);
+
+  useEffect(()=>{
+    if(pubSub.publish){
+      pubSub.publish('ES_FORM', form);
+    }
+  },[form, pubSub.publish]);
+
+  if (isActive || isPublicStatusLoading || formStatusLoading) {
+    return (
+      <div data-testid="loading-view-component">
+        <Loading />
+      </div>
+    );
+  }
+
+  if (isFormSubmitted && !isAuthenticated) {
+    return (
+      <div className="text-center pt-5">
+        <h1>{t("Thank you for your response.")}</h1>
+        <p>{t("saved successfully")}</p>
+      </div>
+    );
+  }
+
+  if (isPublic && !showPublicForm) {
+    return (
+      <div className="alert alert-danger mt-4" role="alert">
+        {t("Form not available")}
+      </div>
+    );
+  }
+  return (
+    <div className="container overflow-y-auto form-view-wrapper">
+      {DRAFT_ENABLED &&
+        isAuthenticated &&
+        isValidResource &&
+        (formStatus === "active" ||
+          (publicFormStatus?.anonymous === true &&
+            publicFormStatus?.status === "active")) && (
+          <>
+            <span className="pr-2  mr-2 d-flex justify-content-end align-items-center">
+              {!notified && (
+                <span className="text-primary">
+                  <i className="fa fa-info-circle mr-2" aria-hidden="true"></i>
+                  {t(
+                    "Unfinished applications will be saved to Applications/Drafts."
+                  )}
+                </span>
+              )}
+
+              {notified && poll && (
+                <SavingLoading
+                  text={
+                    draftSaved
+                      ? t("Saved to Applications/Drafts")
+                      : t("Saving...")
+                  }
+                  saved={draftSaved}
+                />
+              )}
+            </span>
+          </>
+        )}
+      <div className="d-flex align-items-center justify-content-between">
+        <div className="main-header">
+          <SubmissionError
+            modalOpen={props.submissionError.modalOpen}
+            message={props.submissionError.message}
+            onConfirm={props.onConfirm}
+          ></SubmissionError>
+          {isAuthenticated ? (
+            <Link title="go back" to={`${redirectUrl}form`}>
+              <i className="fa fa-chevron-left fa-lg" />
+            </Link>
+          ) : null}
+
+          {form.title ? (
+            <h3 className="ml-3 text-truncate" style={{ height: "45px" }}>
+              <span className="task-head-details">
+                <i className="fa fa-wpforms" aria-hidden="true" /> &nbsp;{" "}
+                {t("Forms")}/
+              </span>{" "}
+              {form.title}
+            </h3>
+          ) : (
+            ""
+          )}
+        </div>
+      </div>
+      <Errors errors={errors} />
+      <LoadingOverlay
+        active={isFormSubmissionLoading}
+        spinner
+        text={<Translation>{(t) => t("Loading...")}</Translation>}
+        className="col-12"
+      >
+  <div className="ml-4 mr-4">
+    {isPublic || formStatus === "active" ? (
+      <Form
+        form={form}
+        submission={submission}
+        url={url}
+        options={{
+          ...options,
+          language: lang,
+          i18n: formio_resourceBundles,
+        }}
+        hideComponents={hideComponents}
+        onChange={(data) => {
+          setDraftData(data);
+          draftRef.current = data;
+        }}
+        onSubmit={(data) => {
+          setPoll(false);
+          exitType.current = "SUBMIT";
+          onSubmit(data, form._id, isPublic);
+        }}
+        onCustomEvent={(evt) => onCustomEvent(evt, redirectUrl)}
+      />
+    ) : (
+      renderPage(formStatus, processLoadError)
+    )}
+  </div>
+      </LoadingOverlay>
+    </div>
+  );
+});
+
+// eslint-disable-next-line no-unused-vars
+const doProcessActions = (submission, ownProps) => {
+  return (dispatch, getState) => {
+    const state = getState();
+    let form = state.form?.form;
+    let isAuth = state.user.isAuthenticated;
+    const tenantKey = state.tenants?.tenantId;
+    const redirectUrl = MULTITENANCY_ENABLED ? `/tenant/${tenantKey}/` : `/`;
+    const origin = `${window.location.origin}${redirectUrl}`;
+    dispatch(resetSubmissions("submission"));
+    const data = getProcessReq(form, submission._id, origin);
+    let draft_id = state.draft.draftSubmission?.id;
+    let isDraftCreated = draft_id ? true : false;
+    const applicationCreateAPI = selectApplicationCreateAPI(
+      isAuth,
+      isDraftCreated,
+      DRAFT_ENABLED
+    );
+
+    dispatch(
+      // eslint-disable-next-line no-unused-vars
+      applicationCreateAPI(data, draft_id ? draft_id : null, (err, res) => {
+        dispatch(setFormSubmissionLoading(false));
+        if (!err) {
+          toast.success(
+            <Translation>{(t) => t("Submission Saved")}</Translation>
+          );
+          dispatch(setFormSubmitted(true));
+          if (isAuth) {
+            dispatch(setMaintainBPMFormPagination(true));
+            dispatch(push(`${redirectUrl}form`));
+          }
+        } else {
+          toast.error(
+            <Translation>{(t) => t("Submission Failed.")}</Translation>
+          );
+        }
+      })
+    );
+  };
+};
+
+const mapStateToProps = (state) => {
+  return {
+    user: state.user.userDetail,
+    tenant: state?.tenants?.tenantId,
+    form: selectRoot("form", state),
+    isAuthenticated: state.user.isAuthenticated,
+    errors: [selectError("form", state), selectError("submission", state)],
+    options: {
+      noAlerts: false,
+      i18n: {
+        en: {
+          error: <Translation>{(t) => t("Message")}</Translation>,
+        },
+      },
+    },
+    submissionError: selectRoot("formDelete", state).formSubmissionError,
+  };
+};
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    onSubmit: (submission, formId, isPublic) => {
+      dispatch(setFormSubmissionLoading(true));
+      // this is callback function for submission
+      const callBack = (err, submission) => {
+        if (!err) {
+          dispatch(doProcessActions(submission, ownProps));
+        } else {
+          const ErrorDetails = {
+            modalOpen: true,
+            message: (
+              <Translation>
+                {(t) => t("Submission cannot be done.")}
+              </Translation>
+            ),
+          };
+          toast.error(
+            <Translation>{(t) => t("Submission cannot be done.")}</Translation>
+          );
+          dispatch(setFormSubmissionLoading(false));
+          dispatch(setFormSubmissionError(ErrorDetails));
+        }
+      };
+      if (CUSTOM_SUBMISSION_URL && CUSTOM_SUBMISSION_ENABLE) {
+        postCustomSubmission(submission, formId, isPublic, callBack);
+      } else {
+        dispatch(saveSubmission("submission", submission, formId, callBack));
+      }
+    },
+    onCustomEvent: (customEvent, redirectUrl) => {
+      switch (customEvent.type) {
+        case CUSTOM_EVENT_TYPE.CUSTOM_SUBMIT_DONE:
+          toast.success("Submission Saved.");
+          dispatch(push(`${redirectUrl}form`));
+          break;
+        case CUSTOM_EVENT_TYPE.CANCEL_SUBMISSION:
+          dispatch(push(`${redirectUrl}form`));
+          break;
+        default:
+          return;
+      }
+    },
+    onConfirm: () => {
+      const ErrorDetails = { modalOpen: false, message: "" };
+      dispatch(setFormSubmissionError(ErrorDetails));
+    },
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(View);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR includes the micro-frontend relevant to the error message appearing in the `Summary of Site Condition` form. Now, instead of `Error while Submission.`, we will show `Submission cannot be done.`. This will keep it consistent with other toasts in the application and will support translation via the existent localization profiles.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce it, follow the steps below:

1. Click on `Submit New` in the `Summary of Site Condition` form.
1. Open your Dev Tools Console and set the network to `offline`.
1. Fill the form as appropriate.
1. Submit the form and check the error message.

If all steps were followed correctly, you should see a toast with the following error message:

![image](https://github.com/bcgov/nr-epd-digital-services/assets/149617222/67ec0d3f-79e1-4277-a2aa-539817b3e175)

Localization works with it:

![image](https://github.com/bcgov/nr-epd-digital-services/assets/149617222/5b7b83a8-1706-407f-a77c-d79f239b4608)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

N/A