### PR TITLE
feat!: change the URL used for the logo in the email templates

### DIFF
--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/docker-compose.yml
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - CHES_SECRET=56b613b2-fbf8-481a-b464-38967c66e066
       - CHES_AUTH_URL=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
       - CHES_HOST_URL=https://ches-dev.api.gov.bc.ca
+      - APP_HOST=${APP_HOST:-epd-frontend-dev.apps.silver.devops.gov.bc.ca}
 
     networks:
       - forms-flow-bpm-network

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/processes/Common/CommonEmailWorkflow.bpmn
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/processes/Common/CommonEmailWorkflow.bpmn
@@ -122,7 +122,7 @@ system.out.println ("result: "+result);</bpmn:script>
           <camunda:inputParameter name="category">${category}</camunda:inputParameter>
           <camunda:inputParameter name="host">
             <camunda:script scriptFormat="javascript">const host = (java.lang.System).getenv('APP_HOST');
-console.log(`Host: ${host}`);
+console.log(`host: ${host}`);
 execution.setVariable("host", host);</camunda:script>
           </camunda:inputParameter>
           <camunda:outputParameter name="support">

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/processes/Common/CommonEmailWorkflow.bpmn
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/processes/Common/CommonEmailWorkflow.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_08oxgyg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_08oxgyg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.18.0" modeler:executionPlatform="Camunda Platform">
   <bpmn:process id="common-email-workflow" name="CommonEmailWorkflow" isExecutable="true" camunda:historyTimeToLive="300">
     <bpmn:startEvent id="Event_0kew5uc" name="Start">
       <bpmn:outgoing>Flow_15fflso</bpmn:outgoing>
@@ -120,6 +120,11 @@ system.out.println ("result: "+result);</bpmn:script>
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="category">${category}</camunda:inputParameter>
+          <camunda:inputParameter name="host">
+            <camunda:script scriptFormat="javascript">const host = (java.lang.System).getenv('APP_HOST');
+console.log(`Host: ${host}`);
+execution.setVariable("host", host);</camunda:script>
+          </camunda:inputParameter>
           <camunda:outputParameter name="support">
             <camunda:script scriptFormat="groovy">dmnResult.get("support")</camunda:script>
           </camunda:outputParameter>
@@ -146,34 +151,6 @@ system.out.println ("result: "+result);</bpmn:script>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="common-email-workflow">
-      <bpmndi:BPMNEdge id="Flow_0tc827u_di" bpmnElement="Flow_0tc827u">
-        <di:waypoint x="740" y="120" />
-        <di:waypoint x="780" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1uskeb8_di" bpmnElement="Flow_1uskeb8">
-        <di:waypoint x="610" y="120" />
-        <di:waypoint x="640" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1v2p747_di" bpmnElement="Flow_1v2p747">
-        <di:waypoint x="470" y="120" />
-        <di:waypoint x="510" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lr16lw_di" bpmnElement="Flow_1lr16lw">
-        <di:waypoint x="1030" y="120" />
-        <di:waypoint x="1072" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_15fflso_di" bpmnElement="Flow_15fflso">
-        <di:waypoint x="208" y="120" />
-        <di:waypoint x="240" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_093urcj_di" bpmnElement="Flow_093urcj">
-        <di:waypoint x="880" y="120" />
-        <di:waypoint x="930" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0cog7s9_di" bpmnElement="Flow_0cog7s9">
-        <di:waypoint x="340" y="120" />
-        <di:waypoint x="370" y="120" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0kew5uc_di" bpmnElement="Event_0kew5uc">
         <dc:Bounds x="172" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -205,6 +182,34 @@ system.out.println ("result: "+result);</bpmn:script>
       <bpmndi:BPMNShape id="ScriptTask_1l8slzj_di" bpmnElement="Task_1q29nrc">
         <dc:Bounds x="640" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0cog7s9_di" bpmnElement="Flow_0cog7s9">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="370" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_093urcj_di" bpmnElement="Flow_093urcj">
+        <di:waypoint x="880" y="120" />
+        <di:waypoint x="930" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15fflso_di" bpmnElement="Flow_15fflso">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lr16lw_di" bpmnElement="Flow_1lr16lw">
+        <di:waypoint x="1030" y="120" />
+        <di:waypoint x="1072" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v2p747_di" bpmnElement="Flow_1v2p747">
+        <di:waypoint x="470" y="120" />
+        <di:waypoint x="510" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uskeb8_di" bpmnElement="Flow_1uskeb8">
+        <di:waypoint x="610" y="120" />
+        <di:waypoint x="640" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tc827u_di" bpmnElement="Flow_0tc827u">
+        <di:waypoint x="740" y="120" />
+        <di:waypoint x="780" y="120" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/nir_application.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/nir_application.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="nir_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/nom_application.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/nom_application.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="nom_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/request_updated.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/request_updated.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="nom_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sds_application.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sds_application.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="nir_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sir_application_approved.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sir_application_approved.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="sir_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sir_application_rejected.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sir_application_rejected.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="sir_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sosc_application.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/sosc_application.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="sosc_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/srcr_application.ftl
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/templates/srcr_application.ftl
@@ -12,7 +12,7 @@
     <table style="width: 580px;">
         <tr>
             <td style="width: 151px;">
-                <img style="width: 151px;" src="https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png">
+                <img style="width: 151px;" src="https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png">
             </td>
             <td>
                 <span id="srcr_notification" style="overflow: visible;line-height: 30px;text-align: left;font-style: normal;font-weight: bold;font-size: 20px;color: rgba(0, 51, 102, 1);letter-spacing: -0.2px;vertical-align: middle;">Site Remediation Services</span>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR introduces a significant enhancement to our application's configuration by adding a new environment variable, `APP_HOST`. The primary purpose of this addition is to improve the flexibility and adaptability of our application across different environments such as development, testing, and production.

## Changes:

- **Introduction of `APP_HOST` Environment Variable**: 
  - The `APP_HOST` variable holds the host address where our application is running. Its versatility allows us to dynamically fetch resources like email logos corresponding to the environment in use. This change is particularly beneficial for ensuring that our application remains consistent and reliable across various deployment stages.
  - I've chosen a generic name (`APP_HOST`) for broader applicability, anticipating future scenarios where the host information might be required. However, if we find its usage limited to email logos, a more specific name like `EMAIL_LOGO_HOST_URL` can be considered. Feedback on this aspect is particularly welcome.
  - Default value in `forms-flow-bpm/docker-compose.yml`:
    ```yaml
    - APP_HOST=${APP_HOST:-epd-frontend-dev.apps.silver.devops.gov.bc.ca}
    ```

- **Update to Email Templates**: 
  - We're transitioning from a hardcoded logo URL (`https://taft.fin.gov.bc.ca/img/BCID_H_rgb_pos_150.png`) to a dynamic one that incorporates the `APP_HOST` value. This update enhances our email system's flexibility and consistency across different deployment environments.
  - New logo URL format: `https://${host}/static/media/logo-banner.e5eec500e32dc7377862.png`, where `host` is derived from `APP_HOST`.

- **Modification of `CommonEmailWorkflow.bpmn`**: 
  - The `EmailTemplate` business rule task now includes the `host` input, ensuring that our email workflows correctly utilize the new dynamic host information.
  - Implementation snippet:
    ```javascript
    const host = (java.lang.System).getenv('APP_HOST');
    console.log(`host: ${host}`);
    execution.setVariable("host", host);
    ```

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

> [!CAUTION]
> If `APP_HOST` is not set, `forms-flow-bpm` will fail to populate `host` in email templates. Post-merge, it's essential to include this variable in the OpenShift deployments for each environment.

# How Has This Been Tested?

I have created a simple workflow that incorporates the `CommonEmailWorkflow`:

<img width="606" alt="image" src="https://github.com/bcgov/nr-epd-digital-services/assets/149617222/db9bfcdb-bd9b-4298-ad97-03589aa41f6d">

After setting `APP_ENV` I can validate that the logo is coming from the pertinent environment instead of the hard-coded URL:

**Before:**

<img width="651" alt="image" src="https://github.com/bcgov/nr-epd-digital-services/assets/149617222/fcb41896-2079-4ac7-8a3c-4e412c9636b5">

**After:**

<img width="659" alt="image" src="https://github.com/bcgov/nr-epd-digital-services/assets/149617222/aa0d1c7c-d070-40ee-99bc-75dd80f2170a">

In the example above APP_HOST is set to `epd-frontend-dev.apps.silver.devops.gov.bc.ca`.