### PR TITLE
fix for connection retry issue

### DIFF
--- a/etl/ReadMe.md
+++ b/etl/ReadMe.md
@@ -88,7 +88,7 @@ curl -u <username>:<password> -H "Content-Type: application/json" -d @register-p
 ```
 curl -u <username>:<password> -H "Content-Type: application/json" -d @register-oracle-jdbc-sink-connector.json http://localhost:8083/connectors/
 
-curl -u <username>:<password> -H "Content-Type: application/json" -d @register-oracle-jdbc-sink-connector.json https://debezium-jdbc-latest.apps.silver.devops.gov.bc.ca/connectors/
+curl -u <username>:<password> -H "Content-Type: application/json" -d @register-oracle-jdbc-sink-connector.json https://debezium-jdbc-dev.apps.silver.devops.gov.bc.ca/connectors/
 
 
 ```

--- a/etl/register-postgres-source-connector.json
+++ b/etl/register-postgres-source-connector.json
@@ -15,6 +15,11 @@
     "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
     "transforms.unwrap.drop.tombstones": "false",
     "include.schema.changes": "false",
-    "time.precision.mode":"connect"
+    "time.precision.mode":"connect",
+    "heartbeat.action.query": "SELECT 1;",
+    "errors.retry.timeout": -1,
+    "errors.max.retries": "5",
+    "retry.backoff.ms": "30000",
+    "retriable.restart.connector.wait.ms": "30000"
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When postgres db connection is timeout, connector should retry. This fix resolves issue partly by retrying after 30 sec. If the db is not back within 30 sec, connector will be shut down. Helps to reconnect after short network glitches.

Fixes # (issue)

SRS-211

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Register the postgres and Oracle connector and test end to end connectivity by issuing an sql statement in postgres. Shut down postgres db for less than 10 sec and start immediately. You can see that connection will be reestablished after retry.
- [ ] Shut down postgres db for more than 30 sec and start database again. You can see that retry is failing and connector is shut down soon.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
