### PR TITLE
chore: add `args` and platform to run it locally in arm

### DIFF
--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/Dockerfile
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/Dockerfile
@@ -48,7 +48,7 @@ COPY ./processes /tmp/src/main/resources/processes
 RUN mvn -s /usr/share/maven/ref/settings-docker.xml package -P default
 
 # Final custom slim java image (for apk command see 17-jdk-alpine-slim)
-FROM openjdk:17-jdk-alpine
+FROM --platform=linux/x86_64 openjdk:17-jdk-alpine
 
 ENV JAVA_VERSION=17-ea+14
 ENV JAVA_HOME=/opt/java/openjdk-17\

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/docker-compose.yml
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-bpm/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      args:
+        - ssh_prv_key=${SSH_PRV_KEY}
+        - ssh_pub_key=${SSH_PUB_KEY}
     restart: always
     links:
       - forms-flow-bpm-db

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-web-root-config/docker-compose.yml
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-web-root-config/docker-compose.yml
@@ -11,6 +11,8 @@ services:
         - MF_FORMSFLOW_ADMIN_URL=${MF_FORMSFLOW_ADMIN_URL:-https://forms-flow-microfrontends.aot-technologies.com/forms-flow-admin@v5.2.1-alpha/forms-flow-admin.gz.js}
         - MF_FORMSFLOW_THEME_URL=${MF_FORMSFLOW_THEME_URL:-https://forms-flow-microfrontends.aot-technologies.com/forms-flow-theme@v5.2.1-alpha/forms-flow-theme.gz.js}
         - NODE_ENV=${NODE_ENV:-production}
+        - ssh_prv_key=${SSH_PRV_KEY}
+        - ssh_pub_key=${SSH_PUB_KEY}
     entrypoint: /bin/sh -c "/usr/share/nginx/html/config/env.sh && nginx -g 'daemon off;'"
     environment:
       - NODE_ENV=${NODE_ENV:-production}

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/docker-compose.yaml
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/docker-compose.yaml
@@ -4,6 +4,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - ssh_prv_key=${SSH_PRV_KEY}
+        - ssh_pub_key=${SSH_PUB_KEY}
     ports:
       - "3004:8080"
     tty: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

The local setup will fail when running the BPM's compose in Apple Silicon. This happens because the `openjdk:17-jdk-alpine` does not support ARM-based platforms. The workaround is to explicitly tell Docker which platform it should try to use via the `--platform=linux/x86_64` parameter. However, this will only work with BuildKit enabled - which is the default as of version 23.0.

Additionally, this PR adds the arguments `ssh_prv_key` and `ssh_pub_key` to all compose files building Dockerfiles that require them.




