### PR TITLE
fix: docker-compose incorrect indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,39 +164,39 @@ services:
       - /app/node_modules
     working_dir: "/app"
 
-frontend:
-  container_name: frontend
-  entrypoint:
-    - "sh"
-    - "-c"
-    - "npm i && npm run start"
-  environment:
-    - WATCHPACK_POLLING=true
-    - NODE_ENV=development
-    - BACKEND_URL=backend
-  healthcheck:
-    test: [ "CMD", "curl", "-f", "http://localhost:4000" ]
-    interval: 1m30s
-    timeout: 10s
-    retries: 3
-    start_period: 40s
-  hostname: frontend
-  image: node:14
-  links:
-    - graphqlgateway
-  ports:
-    - "4000:3000"
-    - "35729:35729"
-  volumes:
-    - ./frontend:/app:z
-    - /app/node_modules
-  working_dir: "/app"
+  frontend:
+    container_name: frontend
+    entrypoint:
+      - "sh"
+      - "-c"
+      - "npm i && npm run start"
+    environment:
+      - WATCHPACK_POLLING=true
+      - NODE_ENV=development
+      - BACKEND_URL=backend
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:4000" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    hostname: frontend
+    image: node:14
+    links:
+      - graphqlgateway
+    ports:
+      - "4000:3000"
+      - "35729:35729"
+    volumes:
+      - ./frontend:/app:z
+      - /app/node_modules
+    working_dir: "/app"
 
-userapi_doc:
-  container_name: userapi_doc
-  build:
-    context: ./backend/documentation/users
-    dockerfile: ./Dockerfile
-  restart: always
-  ports:
-    - "4001:4001"
+  userapi_doc:
+    container_name: userapi_doc
+    build:
+      context: ./backend/documentation/users
+      dockerfile: ./Dockerfile
+    restart: always
+    ports:
+      - "4001:4001"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Correct indentation in docker-compose.yml

This fixes the following issue:

```
❯ docker-compose up -d database
validating /Users/bolaney/Source/github.com/bcgov/nr-epd-digital-services/docker-compose.yml: (root) Additional property userapi_doc is not allowed

nr-epd-digital-services on  dev [$!?] via 🐳 colima via  v23.7.0 
❯ docker-compose up -d database
validating /Users/bolaney/Source/github.com/bcgov/nr-epd-digital-services/docker-compose.yml: (root) Additional property frontend is not allowed
```