### PR TITLE
chore: CATS - fix codegen when running concurrently with dev build

### DIFF
--- a/cats-frontend/package.json
+++ b/cats-frontend/package.json
@@ -49,12 +49,13 @@
   },
   "scripts": {
     "start": "npm run dev",
-    "dev": "concurrently \"vite\" \"graphql-codegen --watch\"",
+    "dev": "concurrently \"vite\" \"npm run codegen:watch\"",
     "build": "vite build",
     "serve": "vite preview",
     "test": "vitest",
     "test:cov": "npm test -- --coverage",
     "codegen": "graphql-codegen --config ./codegen.mts",
+    "codegen:watch": "npm run codegen -- --watch",
     "format": "prettier --write \"./src/**/*.{js,ts,jsx,tsx,json,css}\""
   },
   "eslintConfig": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

#789 added a config argument to the codegen script.
I missed the fact that we also need to add the same argument to codegen when running `dev` script. This PR fixes it.