### PR TITLE
chore: re-add cats unit tests, disable sonarcloud for the time being

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -30,50 +30,50 @@ jobs:
     uses: ./.github/workflows/_code-cov.yml
     strategy:
       matrix:
-        component: [backend/applications, backend/gateway, frontend]
+        component: [backend/applications, backend/gateway, backend/cats, frontend, cats-frontend]
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       component: ${{ matrix.component }}
       lcov_file: ${{ matrix.component }}/coverage/lcov.info
       test_cmd: npm run test:cov
-  sonarcloud:
-    name: Static Analysis
-    needs:
-      - tests
-    runs-on: ubuntu-22.04
-    steps:
-      # Disable shallow clone for SonarCloud analysis
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Get backend coverage from cache
-        uses: actions/cache@v3
-        with:
-          path: backend/coverage
-          key: coverage-backend-${{ github.run_number }}
-          restore-keys: |
-            coverage-backend-
-      - name: Get frontend coverage from cache
-        uses: actions/cache@v3
-        with:
-          path: frontend/coverage
-          key: coverage-frontend-${{ github.run_number }}
-          restore-keys: |
-            coverage-frontend-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.exclusions=backend/applications/src/*.spec.ts,backend/gateway/src/*.spec.ts,backend/applications/src/**/*.spec.ts,backend/gateway/src/**/*.spec.ts
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
-            -Dsonar.cobertura.reportPaths=backend/coverage/cobertura-coverage.xml,frontend/coverage/cobertura-coverage.xml
-            -Dsonar.project.monorepo.enabled=true
-            -Dsonar.projectKey=${{ github.event.repository.name }}
-            -Dsonar.sources=backend/applications/src/,backend/gateway/src/,frontend/src/
-            -Dsonar.tests=backend/applications/src/,backend/gateway/src/
-            -Dsonar.test.inclusions=backend/applications/src/*.spec.ts,backend/gateway/src/*.spec.ts,backend/applications/src/**/*.spec.ts,backend/gateway/src/**/*.spec.ts
+  # sonarcloud:
+  #   name: Static Analysis
+  #   needs:
+  #     - tests
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     # Disable shallow clone for SonarCloud analysis
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Get backend coverage from cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: backend/coverage
+  #         key: coverage-backend-${{ github.run_number }}
+  #         restore-keys: |
+  #           coverage-backend-
+  #     - name: Get frontend coverage from cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: frontend/coverage
+  #         key: coverage-frontend-${{ github.run_number }}
+  #         restore-keys: |
+  #           coverage-frontend-
+  #     - name: SonarCloud Scan
+  #       uses: SonarSource/sonarcloud-github-action@master
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #       with:
+  #         args: >
+  #           -Dsonar.exclusions=backend/applications/src/*.spec.ts,backend/gateway/src/*.spec.ts,backend/applications/src/**/*.spec.ts,backend/gateway/src/**/*.spec.ts
+  #           -Dsonar.organization=bcgov-sonarcloud
+  #           -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
+  #           -Dsonar.cobertura.reportPaths=backend/coverage/cobertura-coverage.xml,frontend/coverage/cobertura-coverage.xml
+  #           -Dsonar.project.monorepo.enabled=true
+  #           -Dsonar.projectKey=${{ github.event.repository.name }}
+  #           -Dsonar.sources=backend/applications/src/,backend/gateway/src/,frontend/src/
+  #           -Dsonar.tests=backend/applications/src/,backend/gateway/src/
+  #           -Dsonar.test.inclusions=backend/applications/src/*.spec.ts,backend/gateway/src/*.spec.ts,backend/applications/src/**/*.spec.ts,backend/gateway/src/**/*.spec.ts

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -21,8 +21,6 @@ jobs:
             triggers: ('backend/applications/')
           - component: backend/gateway
             triggers: ('backend/gateway/')
-          # - component: backend/users
-          #   triggers:  ('backend/users/')
           - component: frontend
             triggers: ('frontend/')
 
@@ -39,7 +37,7 @@ jobs:
     uses: ./.github/workflows/_code-cov.yml
     strategy:
       matrix:
-        component: [backend/applications, backend/gateway, frontend]
+        component: [backend/applications, backend/gateway, backend/cats, frontend, cats-frontend]
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
Re-enable cats unit tests on PR open and PR to dev. Disable sonarcloud for the time being until we can get the secret set up to enable it to pass sucessfully.