### PR TITLE
chore: update cats backend dockerfile healthcheck

### DIFF
--- a/backend/cats/Dockerfile
+++ b/backend/cats/Dockerfile
@@ -1,5 +1,5 @@
 # RedHat UBI 8 with nodejs 14
-FROM node:14.5.0-alpine
+FROM node:22-alpine
 #FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.17.1-alpine
 
 # Install packages, build and keep only prod packages

--- a/backend/cats/local.Dockerfile
+++ b/backend/cats/local.Dockerfile
@@ -1,5 +1,4 @@
-# RedHat UBI 8 with nodejs 14
-FROM node:14.5.0-alpine
+FROM node:22-alpine
 #FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.17.1-alpine
 
 # Install packages, build and keep only prod packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     volumes:
       - ./backend/cats:/app:z
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:4005" ]
+      test: [ "CMD", "wget", "--spider", "http://localhost:4005" ]
       interval: 1m30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
A quick update to our docker system to make the cats backend pass it's healthcheck.

1. Alpine doesn't ship with `curl`, but it does ship with `wget`. the `--spider` option just tells it to not actually download anything.
2. Update the alpine images to node 22. I'm not sure why, but the old versions were still failing the healthcheck, but this one works. In any case we should be using the latest LTS release.