### PR TITLE
fix: Add few fields to be nullable in AppParticipant table

### DIFF
--- a/backend/cats/src/app/entities/appParticipant.entity.ts
+++ b/backend/cats/src/app/entities/appParticipant.entity.ts
@@ -37,12 +37,12 @@ export class AppParticipant {
   isMainParticipant: boolean;
 
   @Column('date', { name: 'effective_start_date' })
-  effectiveStartDate: string;
+  effectiveStartDate: Date;
 
   @Column('date', { name: 'effective_end_date', nullable: true })
-  effectiveEndDate: string | null;
+  effectiveEndDate: Date | null;
 
-  @Column('integer', { name: 'row_version_count' })
+  @Column('integer', { name: 'row_version_count', nullable: true })
   rowVersionCount: number;
 
   @Column('character varying', { name: 'created_by', length: 20 })
@@ -51,13 +51,13 @@ export class AppParticipant {
   @Column('timestamp without time zone', { name: 'created_date_time' })
   createdDateTime: Date;
 
-  @Column('character varying', { name: 'updated_by', length: 20 })
+  @Column('character varying', { name: 'updated_by', length: 20, nullable: true })
   updatedBy: string;
 
-  @Column('timestamp without time zone', { name: 'updated_date_time' })
+  @Column('timestamp without time zone', { name: 'updated_date_time', nullable: true })
   updatedDateTime: Date;
 
-  @Column('bytea', { name: 'ts' })
+  @Column('bytea', { name: 'ts', nullable: true })
   ts: Buffer;
 
   @ManyToOne(() => Application, (application) => application.appParticipants)

--- a/backend/cats/src/migrations/1742493703576-master-script.ts
+++ b/backend/cats/src/migrations/1742493703576-master-script.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class masterScript1742493703576 implements MigrationInterface {
+    name = 'masterScript1742493703576'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "row_version_count" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "updated_by" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "updated_date_time" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "ts" DROP NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "ts" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "updated_date_time" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "updated_by" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "cats"."app_participant" ALTER COLUMN "row_version_count" SET NOT NULL`);
+    }
+
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

There are few fields which could be null, thus changed them in the entity class for App Pariticipant



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-829-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-829-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)