### PR TITLE
fix: Remove bad condition from appsearch query

### DIFF
--- a/backend/cats/src/app/services/application/applicationSearch.service.ts
+++ b/backend/cats/src/app/services/application/applicationSearch.service.ts
@@ -45,9 +45,7 @@ export class ApplicationSearchService {
       .leftJoinAndSelect('application.appStatus', 'appStatus')
       .leftJoinAndSelect('appStatus.statusType', 'statusType')
       .leftJoinAndSelect('application.appPriorities', 'appPriority')
-      .leftJoinAndSelect('appPriority.priority', 'priority')
-      .andWhere('appStatus.isCurrent = true')
-      .andWhere('appPriority.isCurrent = true');
+      .leftJoinAndSelect('appPriority.priority', 'priority');
     query.andWhere(
       new Brackets((qb) => {
         qb.where('CAST(application.id AS TEXT) LIKE :searchParam', {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Fixes a bad condition on the application search query. An analysis of the data
shows that the removed conditions are not valid.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-838-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-838-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)