### PR TITLE
feat: changes to pick app type from db

### DIFF
--- a/backend/cats/src/app/cats.module.ts
+++ b/backend/cats/src/app/cats.module.ts
@@ -63,6 +63,7 @@ import { ApplicationHousingService } from './services/application/applicationHou
 import { ApplicationHousingResolver } from './resolvers/application/applicationHousing.resolver';
 import { ApplicationResolver } from './resolvers/application/application.resolver';
 import { ApplicationService } from './services/application/application.service';
+import { AppTypeService } from './services/appType/appType.service';
 /**
  * Module for wrapping all functionalities in user microserivce
  */
@@ -134,6 +135,7 @@ import { ApplicationService } from './services/application/application.service';
     ApplicationHousingService,
     ApplicationResolver,
     ApplicationService,
+    AppTypeService,
   ],
   controllers: [UserController],
 })

--- a/backend/cats/src/app/dto/application/createApplication.dto.ts
+++ b/backend/cats/src/app/dto/application/createApplication.dto.ts
@@ -12,7 +12,7 @@ export class CreateApplication {
     siteId: number; // site for which the application is created
 
     @Field()
-    appType: string; // the application type eg: SDS, SoSC etc
+    appTypeAbbrev: string; // the application type eg: SDS, SoSC etc
 
     @Field()
     receivedDate: Date; // date when application was submitted in SRS

--- a/backend/cats/src/app/dto/application/createApplication.dto.ts
+++ b/backend/cats/src/app/dto/application/createApplication.dto.ts
@@ -4,7 +4,6 @@ import { Field, InputType } from '@nestjs/graphql';
 @InputType()
 export class CreateApplication {
     @Field()
-    applicationId: number; // ID of the new application in CATS
 
     @Field()
     srsApplicationId: number; // ID of the new application in SRS
@@ -13,7 +12,7 @@ export class CreateApplication {
     siteId: number; // site for which the application is created
 
     @Field()
-    appTypeId: number; // the application type eg: SDS, SoSC etc
+    appType: string; // the application type eg: SDS, SoSC etc
 
     @Field()
     receivedDate: Date; // date when application was submitted in SRS

--- a/backend/cats/src/app/resolvers/application/application.resolver.spec.ts
+++ b/backend/cats/src/app/resolvers/application/application.resolver.spec.ts
@@ -64,7 +64,7 @@ describe('ApplicationResolver', () => {
     const createApplicationDto: CreateApplication = {
       srsApplicationId: 11,
       siteId: 123,
-      appType: 'CSR',
+      appTypeAbbrev: 'CSR',
       receivedDate: new Date()
     };
 
@@ -97,7 +97,7 @@ describe('ApplicationResolver', () => {
     const createApplicationDto: CreateApplication = {
       srsApplicationId: 11,
       siteId: 123,
-      appType: 'TEST',
+      appTypeAbbrev: 'TEST',
       receivedDate: new Date()
     };
 

--- a/backend/cats/src/app/resolvers/application/application.resolver.spec.ts
+++ b/backend/cats/src/app/resolvers/application/application.resolver.spec.ts
@@ -62,10 +62,9 @@ describe('ApplicationResolver', () => {
 
   it('should create an application successfully', async () => {
     const createApplicationDto: CreateApplication = {
-      applicationId: 1,
       srsApplicationId: 11,
       siteId: 123,
-      appTypeId: 2,
+      appType: 'CSR',
       receivedDate: new Date()
     };
 
@@ -96,10 +95,9 @@ describe('ApplicationResolver', () => {
 
   it('should return an error when creation of application fails', async () => {
     const createApplicationDto: CreateApplication = {
-      applicationId: 1,
       srsApplicationId: 11,
       siteId: 123,
-      appTypeId: 2,
+      appType: 'TEST',
       receivedDate: new Date()
     };
 

--- a/backend/cats/src/app/services/appType/appType.service.spec.ts
+++ b/backend/cats/src/app/services/appType/appType.service.spec.ts
@@ -28,19 +28,19 @@ describe('AppTypeService', () => {
 
   describe('getAppTypeByDescription', () => {
     it('should fetch app type successfully for valid abbrev', async () => {
-      const appType = 'CSR';
+      const appTypeAbbrev = 'CSR';
       const mockAppType = { id: 1 };
       repository.findOne = jest.fn().mockResolvedValue(mockAppType);
 
-      const result = await service.getAppTypeByDescription(appType);
+      const result = await service.getAppTypeByAbbrev(appTypeAbbrev);
       expect(result).toEqual({ id: 1, });
     });
 
     it('should return empty array if no app type found', async () => {
-      const appType = 'TEST';
+      const appTypeAbbrev = 'TEST';
       repository.findOne = jest.fn().mockResolvedValue([]);
 
-      const result = await service.getAppTypeByDescription(appType);
+      const result = await service.getAppTypeByAbbrev(appTypeAbbrev);
       expect(result).toEqual({ "id": undefined });
     });
   });

--- a/backend/cats/src/app/services/appType/appType.service.spec.ts
+++ b/backend/cats/src/app/services/appType/appType.service.spec.ts
@@ -1,0 +1,47 @@
+import { AppTypeService } from './appType.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { LoggerService } from '../../logger/logger.service';
+import { AppType } from '../../entities/appType.entity';
+
+describe('AppTypeService', () => {
+  let service: AppTypeService;
+  let repository: Repository<AppType>;
+  let loggerService: LoggerService;
+
+  beforeEach(() => {
+    repository = {
+      findOne: jest.fn(),
+      findBy: jest.fn(),
+      save: jest.fn(),
+      create: jest.fn(),
+    } as unknown as Repository<AppType>;
+    loggerService = {
+      log: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as LoggerService;
+
+    service = new AppTypeService(repository, loggerService);
+  });
+
+  describe('getAppTypeByDescription', () => {
+    it('should fetch app type successfully for valid abbrev', async () => {
+      const appType = 'CSR';
+      const mockAppType = { id: 1 };
+      repository.findOne = jest.fn().mockResolvedValue(mockAppType);
+
+      const result = await service.getAppTypeByDescription(appType);
+      expect(result).toEqual({ id: 1, });
+    });
+
+    it('should return empty array if no app type found', async () => {
+      const appType = 'TEST';
+      repository.findOne = jest.fn().mockResolvedValue([]);
+
+      const result = await service.getAppTypeByDescription(appType);
+      expect(result).toEqual({ "id": undefined });
+    });
+  });
+});

--- a/backend/cats/src/app/services/appType/appType.service.ts
+++ b/backend/cats/src/app/services/appType/appType.service.ts
@@ -12,17 +12,17 @@ export class AppTypeService {
     private readonly loggerService: LoggerService,
   ) { }
 
-  async getAppTypeByDescription(appTypeDescription: string) {
-    this.loggerService.log('AppTypeService.getAppTypeByDescription() start'); // Log the start of the method
+  async getAppTypeByAbbrev(appTypeAbbrev: string) {
+    this.loggerService.log('AppTypeService.getAppTypeByAbbrev() start'); // Log the start of the method
 
     try {
       // Log the input parameters for better traceability
       this.loggerService.debug(
-        `Fetching application type with description: ${appTypeDescription}`,
+        `Fetching application type with abbrev: ${appTypeAbbrev}`,
       );
 
       const appType = await this.appTypeRepository.findOne({
-        where: { abbrev: appTypeDescription }
+        where: { abbrev: appTypeAbbrev }
       });
 
       if (appType) {
@@ -41,13 +41,13 @@ export class AppTypeService {
     } catch (err) {
       // Log the error with the exception details
       this.loggerService.error(
-        'Exception occurred in AppTypeService.getAppTypeByDescription()',
+        'Exception occurred in AppTypeService.getAppTypeByAbbrev()',
         JSON.stringify(err),
       );
       throw new HttpException('Failed to fetch application type', HttpStatus.BAD_REQUEST);
     } finally {
       // Log the end of the method
-      this.loggerService.log('AppTypeService.getAppTypeByDescription() end');
+      this.loggerService.log('AppTypeService.getAppTypeByAbbrev() end');
     }
   }
 }

--- a/backend/cats/src/app/services/appType/appType.service.ts
+++ b/backend/cats/src/app/services/appType/appType.service.ts
@@ -1,0 +1,53 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AppType } from '../../entities/appType.entity';
+import { LoggerService } from '../../logger/logger.service';
+
+@Injectable()
+export class AppTypeService {
+  constructor(
+    @InjectRepository(AppType)
+    private readonly appTypeRepository: Repository<AppType>,
+    private readonly loggerService: LoggerService,
+  ) { }
+
+  async getAppTypeByDescription(appTypeDescription: string) {
+    this.loggerService.log('AppTypeService.getAppTypeByDescription() start'); // Log the start of the method
+
+    try {
+      // Log the input parameters for better traceability
+      this.loggerService.debug(
+        `Fetching application type with description: ${appTypeDescription}`,
+      );
+
+      const appType = await this.appTypeRepository.findOne({
+        where: { abbrev: appTypeDescription }
+      });
+
+      if (appType) {
+        this.loggerService.log(
+          `Application type found with ID: ${appType.id}`,
+        );
+        return {
+          id: appType.id,
+        };
+      } else {
+        this.loggerService.warn(
+          '`Application type not found',
+        );
+        return null;
+      }
+    } catch (err) {
+      // Log the error with the exception details
+      this.loggerService.error(
+        'Exception occurred in AppTypeService.getAppTypeByDescription()',
+        JSON.stringify(err),
+      );
+      throw new HttpException('Failed to fetch application type', HttpStatus.BAD_REQUEST);
+    } finally {
+      // Log the end of the method
+      this.loggerService.log('AppTypeService.getAppTypeByDescription() end');
+    }
+  }
+}

--- a/backend/cats/src/app/services/application/application.service.spec.ts
+++ b/backend/cats/src/app/services/application/application.service.spec.ts
@@ -50,20 +50,20 @@ describe('ApplicationService', () => {
       const mockCreateApplication = {
         srsApplicationId: 12345,
         siteId: 67890,
-        appType: 'CSR',
+        appTypeAbbrev: 'CSR',
         receivedDate: new Date(),
       };
 
       const mockAppType = { id: 1 };
       const mockNewApplication = { id: 1 };
 
-      appTypeService.getAppTypeByDescription = jest.fn().mockResolvedValue(mockAppType);
+      appTypeService.getAppTypeByAbbrev = jest.fn().mockResolvedValue(mockAppType);
       applicationRepository.create = jest.fn().mockReturnValue(mockNewApplication);
       applicationRepository.save = jest.fn().mockResolvedValue(mockNewApplication);
 
       const result = await applicationService.createApplication(mockCreateApplication);
 
-      expect(appTypeService.getAppTypeByDescription).toHaveBeenCalledWith('CSR');
+      expect(appTypeService.getAppTypeByAbbrev).toHaveBeenCalledWith('CSR');
       expect(applicationRepository.create).toHaveBeenCalled();
       expect(applicationRepository.save).toHaveBeenCalled();
       expect(result).toEqual({ id: 1 });

--- a/backend/cats/src/app/services/application/application.service.spec.ts
+++ b/backend/cats/src/app/services/application/application.service.spec.ts
@@ -1,54 +1,72 @@
 import { ApplicationService } from './application.service';
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import { Repository } from 'typeorm';
 import { LoggerService } from '../../logger/logger.service';
 import { Application } from '../../entities/application.entity';
+import { AppTypeService } from '../appType/appType.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('ApplicationService', () => {
-  let service: ApplicationService;
-  let repository: Repository<Application>;
+  let applicationService: ApplicationService;
+  let applicationRepository: Repository<Application>;
   let loggerService: LoggerService;
+  let appTypeService: AppTypeService;
 
-  beforeEach(() => {
-    repository = {
-      findOne: jest.fn(),
-      findBy: jest.fn(),
-      save: jest.fn(),
-      create: jest.fn(),
-    } as unknown as Repository<Application>;
-    loggerService = {
-      log: jest.fn(),
-      debug: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    } as unknown as LoggerService;
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationService,
+        {
+          provide: AppTypeService,
+          useValue: {
+            getAppTypeByDescription: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Application), // ✅ Correctly mock Repository<Application>
+          useClass: Repository,  // ✅ This ensures it's treated as a repository
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            log: jest.fn(),
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
 
-    service = new ApplicationService(repository, loggerService);
+    applicationService = module.get<ApplicationService>(ApplicationService);
+    appTypeService = module.get<AppTypeService>(AppTypeService);
+    applicationRepository = module.get<Repository<Application>>(getRepositoryToken(Application)); // ✅ Correctly get repository
+    loggerService = module.get<LoggerService>(LoggerService);
   });
 
 
   describe('createApplication', () => {
-    it('should create an application', async () => {
-      const createApplication = {
-        applicationId: 1,
-        srsApplicationId: 11,
-        siteId: 123,
-        appTypeId: 2,
-        receivedDate: new Date()
+    it('should create an application successfully', async () => {
+      const mockCreateApplication = {
+        srsApplicationId: 12345,
+        siteId: 67890,
+        appType: 'CSR',
+        receivedDate: new Date(),
       };
 
-      // Mock repository methods with the correct types
-      const savedApplication = {
-        id: 1,
-      };
+      const mockAppType = { id: 1 };
+      const mockNewApplication = { id: 1 };
 
-      jest.spyOn(repository, 'create').mockReturnValue(savedApplication as any);
-      jest.spyOn(repository, 'save').mockResolvedValue(savedApplication as any);
+      appTypeService.getAppTypeByDescription = jest.fn().mockResolvedValue(mockAppType);
+      applicationRepository.create = jest.fn().mockReturnValue(mockNewApplication);
+      applicationRepository.save = jest.fn().mockResolvedValue(mockNewApplication);
 
-      const result = await service.createApplication(createApplication);
+      const result = await applicationService.createApplication(mockCreateApplication);
 
-      expect(result).toBeDefined();
-      expect(result.id).toBe(savedApplication.id);
+      expect(appTypeService.getAppTypeByDescription).toHaveBeenCalledWith('CSR');
+      expect(applicationRepository.create).toHaveBeenCalled();
+      expect(applicationRepository.save).toHaveBeenCalled();
+      expect(result).toEqual({ id: 1 });
     });
   });
 });

--- a/backend/cats/src/app/services/application/application.service.ts
+++ b/backend/cats/src/app/services/application/application.service.ts
@@ -24,12 +24,12 @@ export class ApplicationService {
         `Attempting to create application with srs app id: ${createApplication?.srsApplicationId}`,
       );
 
-      const appTypeId = await this.appTypeService.getAppTypeByAbbrev(createApplication.appTypeAbbrev);
+      const appType = await this.appTypeService.getAppTypeByAbbrev(createApplication.appTypeAbbrev);
 
       const newApplication = await this.applicationRepository.create({
         siteId: createApplication.siteId,
         srsApplicationId: createApplication.srsApplicationId,
-        appTypeId: appTypeId?.id,
+        appTypeId: appType?.id,
         rowVersionCount: 1,
         createdBy: 'SYSTEM',
         updatedBy: 'SYSTEM',

--- a/backend/cats/src/app/services/application/application.service.ts
+++ b/backend/cats/src/app/services/application/application.service.ts
@@ -24,7 +24,7 @@ export class ApplicationService {
         `Attempting to create application with srs app id: ${createApplication?.srsApplicationId}`,
       );
 
-      const appTypeId = await this.appTypeService.getAppTypeByDescription(createApplication.appType);
+      const appTypeId = await this.appTypeService.getAppTypeByAbbrev(createApplication.appTypeAbbrev);
 
       const newApplication = await this.applicationRepository.create({
         siteId: createApplication.siteId,

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/package-lock.json
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-web/package-lock.json
@@ -59,10 +59,10 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
-        "json5": "2.2.2",
+        "json5": "^2.1.2",
         "lodash": "^4.17.19",
         "resolve": "^1.3.2",
-        "semver": "7.5.3",
+        "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -72,9 +72,9 @@
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -133,12 +133,14 @@
       "requires": {
         "@babel/compat-data": "^7.20.0",
         "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.17.6",
-        "semver": "7.5.3"
+        "browserslist": "^4.21.3",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -174,9 +176,9 @@
           "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         },
         "update-browserslist-db": {
           "version": "1.0.11",
@@ -210,7 +212,7 @@
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "regexpu-core": "^5.3.1",
-        "semver": "7.5.3"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
@@ -242,9 +244,9 @@
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -258,13 +260,13 @@
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
-        "semver": "7.5.3"
+        "semver": "^6.1.2"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -741,7 +743,7 @@
             "@babel/helper-replace-supers": "^7.22.5",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
             "@babel/helper-split-export-declaration": "^7.22.5",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "@babel/helper-annotate-as-pure": {
@@ -753,9 +755,9 @@
               }
             },
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -1268,13 +1270,13 @@
             "@babel/helper-replace-supers": "^7.22.5",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
             "@babel/helper-split-export-declaration": "^7.22.5",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -1472,13 +1474,13 @@
             "@babel/helper-replace-supers": "^7.22.5",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
             "@babel/helper-split-export-declaration": "^7.22.5",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -1681,13 +1683,15 @@
           "requires": {
             "@babel/compat-data": "^7.22.5",
             "@babel/helper-validator-option": "^7.22.5",
-            "browserslist": "^4.17.6",
+            "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "browserslist": {
-              "version": "^4.17.6",
+              "version": "4.21.9",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+              "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
               "requires": {
                 "caniuse-lite": "^1.0.30001503",
                 "electron-to-chromium": "^1.4.431",
@@ -1696,9 +1700,9 @@
               }
             },
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -2089,13 +2093,15 @@
           "requires": {
             "@babel/compat-data": "^7.22.5",
             "@babel/helper-validator-option": "^7.22.5",
-            "browserslist": "^4.17.6",
+            "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "browserslist": {
-              "version": "^4.17.6",
+              "version": "4.21.9",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+              "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
               "requires": {
                 "caniuse-lite": "^1.0.30001503",
                 "electron-to-chromium": "^1.4.431",
@@ -2104,9 +2110,9 @@
               }
             },
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -2997,13 +3003,15 @@
           "requires": {
             "@babel/compat-data": "^7.22.5",
             "@babel/helper-validator-option": "^7.22.5",
-            "browserslist": "^4.17.6",
+            "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "browserslist": {
-              "version": "^4.17.6",
+              "version": "4.21.9",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+              "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
               "requires": {
                 "caniuse-lite": "^1.0.30001503",
                 "electron-to-chromium": "^1.4.431",
@@ -3012,9 +3020,9 @@
               }
             },
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -3348,13 +3356,13 @@
             "@babel/helper-replace-supers": "^7.22.5",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
             "@babel/helper-split-export-declaration": "^7.22.5",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -3553,13 +3561,13 @@
             "@babel/helper-replace-supers": "^7.22.5",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
             "@babel/helper-split-export-declaration": "^7.22.5",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -3808,13 +3816,13 @@
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
-        "semver": "7.5.3"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -4079,7 +4087,7 @@
         "babel-plugin-polyfill-corejs3": "^0.8.1",
         "babel-plugin-polyfill-regenerator": "^0.5.0",
         "core-js-compat": "^3.30.2",
-        "semver": "7.5.3"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "@babel/compat-data": {
@@ -4094,13 +4102,15 @@
           "requires": {
             "@babel/compat-data": "^7.22.5",
             "@babel/helper-validator-option": "^7.22.5",
-            "browserslist": "^4.17.6",
+            "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "browserslist": {
-              "version": "^4.17.6",
+              "version": "4.21.9",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+              "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
               "requires": {
                 "caniuse-lite": "^1.0.30001503",
                 "electron-to-chromium": "^1.4.431",
@@ -4109,9 +4119,9 @@
               }
             },
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -4125,13 +4135,13 @@
             "debug": "^4.1.1",
             "lodash.debounce": "^4.0.8",
             "resolve": "^1.14.2",
-            "semver": "7.5.3"
+            "semver": "^6.1.2"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -4177,13 +4187,13 @@
           "requires": {
             "@babel/compat-data": "^7.17.7",
             "@babel/helper-define-polyfill-provider": "^0.4.0",
-            "semver": "7.5.3"
+            "semver": "^6.1.1"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -4214,11 +4224,13 @@
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.31.0.tgz",
           "integrity": "sha512-hM7YCu1cU6Opx7MXNu0NuumM0ezNeAeRKadixyiQELWY3vT3De9S4J5ZBMraWV2vZnrE1Cirl0GtFtDtMUXzPw==",
           "requires": {
-            "browserslist": "^4.17.6"
+            "browserslist": "^4.21.5"
           },
           "dependencies": {
             "browserslist": {
-              "version": "^4.17.6",
+              "version": "4.21.9",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+              "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
               "requires": {
                 "caniuse-lite": "^1.0.30001503",
                 "electron-to-chromium": "^1.4.431",
@@ -4242,9 +4254,9 @@
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         },
         "update-browserslist-db": {
           "version": "1.0.11",
@@ -4506,7 +4518,7 @@
         "cosmiconfig-typescript-loader": "^1.0.0",
         "cross-spawn": "^7.0.0",
         "lodash": "^4.17.15",
-        "semver": "7.5.3",
+        "semver": "^7.3.2",
         "webpack-merge": "^4.2.2"
       },
       "dependencies": {
@@ -4690,7 +4702,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -4796,7 +4808,7 @@
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.0",
         "debug": "^4.1.1",
-        "minimatch": "3.0.5"
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -5139,13 +5151,13 @@
             "@babel/core": "^7.7.5",
             "@istanbuljs/schema": "^0.1.2",
             "istanbul-lib-coverage": "^3.0.0",
-            "semver": "7.5.3"
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -5550,7 +5562,7 @@
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "requires": {
         "@gar/promisify": "^1.0.1",
-        "semver": "7.5.3"
+        "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
@@ -5603,7 +5615,7 @@
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
       "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
       "requires": {
-        "ansi-html": "^0.0.9",
+        "ansi-html": "^0.0.7",
         "error-stack-parser": "^2.0.6",
         "html-entities": "^1.2.1",
         "native-url": "^0.2.6",
@@ -5611,9 +5623,6 @@
         "source-map": "^0.7.3"
       },
       "dependencies": {
-        "ansi-html": {
-          "version": "^0.0.9"
-        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -5719,13 +5728,8 @@
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz",
       "integrity": "sha512-yBMPqmd1yEJo/280PAMkychuaALyQ9Lkb5q1ck3mjJrFuEobIfhnQ4J3mbvBoISmR3SWMWV+cGB/I0lCQee79A==",
       "requires": {
-        "ejs": ">=3.1.7",
+        "ejs": "^2.6.1",
         "magic-string": "^0.25.0"
-      },
-      "dependencies": {
-        "ejs": {
-          "version": ">=3.1.7"
-        }
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -5862,7 +5866,7 @@
         "@svgr/core": "^5.5.0",
         "@svgr/plugin-jsx": "^5.5.0",
         "@svgr/plugin-svgo": "^5.5.0",
-        "loader-utils": "2.0.4"
+        "loader-utils": "^2.0.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -5872,7 +5876,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -6680,7 +6684,7 @@
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
-        "semver": "7.5.3",
+        "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
@@ -6742,7 +6746,7 @@
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
-        "semver": "7.5.3",
+        "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
@@ -7004,7 +7008,7 @@
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
       "integrity": "sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==",
       "requires": {
-        "loader-utils": "2.0.4",
+        "loader-utils": "^2.0.0",
         "regex-parser": "^2.2.11"
       },
       "dependencies": {
@@ -7015,7 +7019,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -7091,7 +7095,9 @@
       }
     },
     "ansi-html": {
-      "version": "^0.0.9"
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA=="
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -7360,7 +7366,7 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
       "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.12.0",
         "caniuse-lite": "^1.0.30001109",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
@@ -7370,7 +7376,9 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -7540,17 +7548,10 @@
       "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
       "requires": {
         "find-cache-dir": "^2.1.0",
-        "loader-utils": "2.0.4",
+        "loader-utils": "^1.4.0",
         "mkdirp": "^0.5.3",
         "pify": "^4.0.1",
         "schema-utils": "^2.6.5"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw=="
-        }
       }
     },
     "babel-plugin-emotion": {
@@ -7615,13 +7616,13 @@
       "requires": {
         "@babel/compat-data": "^7.17.7",
         "@babel/helper-define-polyfill-provider": "^0.3.3",
-        "semver": "7.5.3"
+        "semver": "^6.1.1"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -7757,8 +7758,8 @@
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
-            "json5": "2.2.2",
-            "semver": "7.5.3"
+            "json5": "^2.2.1",
+            "semver": "^6.3.0"
           },
           "dependencies": {
             "json5": {
@@ -7767,9 +7768,9 @@
               "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
             },
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -8284,7 +8285,9 @@
       }
     },
     "browserslist": {
-      "version": "^4.17.6",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "requires": {
         "caniuse-lite": "^1.0.30001503",
         "electron-to-chromium": "^1.4.431",
@@ -8418,7 +8421,7 @@
         "promise-inflight": "^1.0.1",
         "rimraf": "^3.0.2",
         "ssri": "^8.0.1",
-        "tar": "^6.1.11",
+        "tar": "^6.0.2",
         "unique-filename": "^1.1.1"
       },
       "dependencies": {
@@ -8436,7 +8439,9 @@
           }
         },
         "tar": {
-          "version": "^6.1.11",
+          "version": "6.1.15",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+          "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -8550,14 +8555,16 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
         "lodash.memoize": "^4.1.2",
         "lodash.uniq": "^4.5.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -8650,7 +8657,7 @@
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
         "fsevents": "~2.3.2",
-        "glob-parent": "^6.0.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
@@ -8658,7 +8665,9 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "^6.0.2",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -9069,11 +9078,13 @@
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.1.tgz",
       "integrity": "sha512-622/KzTudvXCDLRw70iHW4KKs1aGpcRcowGWyYJr2DEBfRrd6hNJybxSWJFuZYD4ma86xhrwDDHxmDaIq4EA8A==",
       "requires": {
-        "browserslist": "^4.17.6"
+        "browserslist": "^4.21.4"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -9250,15 +9261,15 @@
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
-        "semver": "7.5.3",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -9372,7 +9383,7 @@
         "camelcase": "^6.0.0",
         "cssesc": "^3.0.0",
         "icss-utils": "^4.1.1",
-        "loader-utils": "2.0.4",
+        "loader-utils": "^2.0.0",
         "postcss": "^7.0.32",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.3",
@@ -9380,7 +9391,7 @@
         "postcss-modules-values": "^3.0.0",
         "postcss-value-parser": "^4.1.0",
         "schema-utils": "^2.7.1",
-        "semver": "7.5.3"
+        "semver": "^7.3.2"
       },
       "dependencies": {
         "loader-utils": {
@@ -9390,7 +9401,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -9426,12 +9437,7 @@
         "boolbase": "^1.0.0",
         "css-what": "^3.2.1",
         "domutils": "^1.7.0",
-        "nth-check": "^2.0.1"
-      },
-      "dependencies": {
-        "nth-check": {
-          "version": "^2.0.1"
-        }
+        "nth-check": "^1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -9680,9 +9686,9 @@
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-format": {
       "version": "1.4.5",
@@ -9694,14 +9700,7 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
       "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
-        "d3-color": "3.1.0"
-      },
-      "dependencies": {
-        "d3-color": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-          "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
-        }
+        "d3-color": "1"
       }
     },
     "d3-path": {
@@ -10505,7 +10504,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "ejs": {
-      "version": ">=3.1.7"
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -10821,7 +10822,7 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.2",
+        "glob-parent": "^5.1.2",
         "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
@@ -10831,12 +10832,12 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
         "regexpp": "^3.1.0",
-        "semver": "7.5.3",
+        "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
         "table": "^6.0.9",
@@ -10913,7 +10914,9 @@
           }
         },
         "glob-parent": {
-          "version": "^6.0.2",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -11056,7 +11059,7 @@
         "has": "^1.0.3",
         "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
         "resolve": "^1.22.0",
         "tsconfig-paths": "^3.14.1"
@@ -11079,9 +11082,9 @@
           }
         },
         "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11117,8 +11120,8 @@
         "has": "^1.0.3",
         "jsx-ast-utils": "^3.3.2",
         "language-tags": "^1.0.5",
-        "minimatch": "3.0.5",
-        "semver": "7.5.3"
+        "minimatch": "^3.1.2",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -11127,17 +11130,17 @@
           "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
         },
         "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -11152,14 +11155,14 @@
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.2",
         "object.entries": "^1.1.6",
         "object.fromentries": "^2.0.6",
         "object.hasown": "^1.1.2",
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
-        "semver": "7.5.3",
+        "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.8"
       },
       "dependencies": {
@@ -11177,9 +11180,9 @@
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         },
         "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11195,9 +11198,9 @@
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -11242,7 +11245,7 @@
             "glob": "^7.1.6",
             "is-glob": "^4.0.1",
             "lodash": "^4.17.15",
-            "semver": "7.5.3",
+            "semver": "^7.3.2",
             "tsutils": "^3.17.1"
           },
           "dependencies": {
@@ -11752,14 +11755,9 @@
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^6.0.2",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "^6.0.2"
-        }
       }
     },
     "fast-json-patch": {
@@ -11836,7 +11834,7 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.1.tgz",
       "integrity": "sha512-Klt8C4BjWSXYQAfhpYYkG4qHNTna4toMHEbWrI5IuVoxbU6uiDKeKAP99R8mmbJi3lvewn/jQBOgU4+NS3tDQw==",
       "requires": {
-        "loader-utils": "2.0.4",
+        "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
@@ -11847,7 +11845,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -11879,7 +11877,7 @@
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
       "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "requires": {
-        "minimatch": "3.0.5"
+        "minimatch": "^5.0.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -11891,9 +11889,9 @@
           }
         },
         "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -12035,8 +12033,8 @@
         "@babel/code-frame": "^7.5.5",
         "chalk": "^2.4.1",
         "micromatch": "^3.1.10",
-        "minimatch": "3.0.5",
-        "semver": "7.5.3",
+        "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
         "tapable": "^1.0.0",
         "worker-rpc": "^0.1.0"
       },
@@ -12136,9 +12134,9 @@
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "to-regex-range": {
           "version": "2.1.1",
@@ -12193,7 +12191,7 @@
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.2",
-        "moment-timezone": "0.5.37",
+        "moment-timezone": "^0.5.34",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
         "resize-observer-polyfill": "^1.5.1",
@@ -12423,20 +12421,15 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw=="
-        }
       }
     },
     "glob-parent": {
-      "version": "^6.0.2",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -12802,7 +12795,7 @@
         "@types/tapable": "^1.0.5",
         "@types/webpack": "^4.41.8",
         "html-minifier-terser": "^5.0.1",
-        "loader-utils": "2.0.4",
+        "loader-utils": "^1.2.3",
         "lodash": "^4.17.15",
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
@@ -12815,19 +12808,19 @@
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^1.0.1"
           },
           "dependencies": {
             "json5": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-              "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+              "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
               "requires": {
                 "minimist": "^1.2.0"
               }
@@ -13123,7 +13116,9 @@
       "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA=="
     },
     "immer": {
-      "version": "^9.0.6"
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "immutable": {
       "version": "4.1.0",
@@ -13798,13 +13793,13 @@
         "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
-        "semver": "7.5.3"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -13828,13 +13823,13 @@
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
-            "semver": "7.5.3"
+            "semver": "^6.0.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -13890,7 +13885,7 @@
         "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
-        "minimatch": "3.0.5"
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14943,7 +14938,7 @@
         "jest-resolve": "^26.6.2",
         "natural-compare": "^1.4.0",
         "pretty-format": "^26.6.2",
-        "semver": "7.5.3"
+        "semver": "^7.3.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15398,9 +15393,9 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "json5": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -15422,7 +15417,7 @@
         "jws": "^3.2.2",
         "lodash": "^4.17.21",
         "ms": "^2.1.1",
-        "semver": "7.5.3"
+        "semver": "^7.3.8"
       },
       "dependencies": {
         "semver": {
@@ -15657,20 +15652,13 @@
       "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
     },
     "loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "2.2.2"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-          "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
-        }
+        "json5": "^1.0.1"
       }
     },
     "locate-path": {
@@ -15866,13 +15854,13 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "requires": {
         "pify": "^4.0.1",
-        "semver": "7.5.3"
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -16062,7 +16050,7 @@
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
       "integrity": "sha512-n9BA8LonkOkW1/zn+IbLPQmovsL0wMb9yx75fMJQZf2X1Zoec9yTZtyMePcyu19wPkmFbzZZA6fLTotpFhQsOA==",
       "requires": {
-        "loader-utils": "2.0.4",
+        "loader-utils": "^1.1.0",
         "normalize-url": "1.9.1",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
@@ -16074,19 +16062,19 @@
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^1.0.1"
           },
           "dependencies": {
             "json5": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-              "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+              "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
               "requires": {
                 "minimist": "^1.2.0"
               }
@@ -16116,9 +16104,9 @@
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -16511,7 +16499,9 @@
       }
     },
     "node-forge": {
-      "version": "^1.2.1"
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp-build": {
       "version": "4.6.0",
@@ -16569,7 +16559,7 @@
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
-        "semver": "7.5.3",
+        "semver": "^7.3.2",
         "shellwords": "^0.1.1",
         "uuid": "^8.3.0",
         "which": "^2.0.2"
@@ -16607,14 +16597,14 @@
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
-        "semver": "7.5.3",
+        "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -16648,7 +16638,9 @@
       }
     },
     "nth-check": {
-      "version": "^2.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
         "boolbase": "~1.0.0"
       }
@@ -17450,7 +17442,7 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
       "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "color": "^3.0.0",
         "has": "^1.0.0",
         "postcss": "^7.0.0",
@@ -17458,7 +17450,9 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -17761,7 +17755,7 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "requires": {
-        "loader-utils": "2.0.4",
+        "loader-utils": "^1.1.0",
         "postcss": "^7.0.0",
         "postcss-load-config": "^2.0.0",
         "schema-utils": "^1.0.0"
@@ -17773,19 +17767,19 @@
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^1.0.1"
           },
           "dependencies": {
             "json5": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-              "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+              "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
               "requires": {
                 "minimist": "^1.2.0"
               }
@@ -17843,7 +17837,7 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
       "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "caniuse-api": "^3.0.0",
         "cssnano-util-same-parent": "^4.0.0",
         "postcss": "^7.0.0",
@@ -17852,7 +17846,9 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -17948,7 +17944,7 @@
       "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
       "requires": {
         "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "cssnano-util-get-arguments": "^4.0.0",
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0",
@@ -17956,7 +17952,9 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -18081,14 +18079,16 @@
       "integrity": "sha512-rt9JMS/m9FHIRroDDBGSMsyW1c0fkvOJPy62ggxSHUldJO7B195TqFMqIf+lY5ezpDcYOV4j86aUp3/XbxzCCQ==",
       "requires": {
         "@csstools/normalize.css": "^10.1.0",
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.6.2",
         "postcss": "^7.0.17",
         "postcss-browser-comments": "^3.0.0",
         "sanitize.css": "^10.0.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -18234,13 +18234,15 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -18378,7 +18380,7 @@
       "integrity": "sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==",
       "requires": {
         "autoprefixer": "^9.6.1",
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.6.4",
         "caniuse-lite": "^1.0.30000981",
         "css-blank-pseudo": "^0.1.4",
         "css-has-pseudo": "^0.10.0",
@@ -18417,7 +18419,9 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -18489,14 +18493,16 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "caniuse-api": "^3.0.0",
         "has": "^1.0.0",
         "postcss": "^7.0.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -19050,14 +19056,7 @@
       "requires": {
         "classnames": "^2.2.5",
         "react-transition-group": "^4.2.0",
-        "underscore": "1.12.1"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
-        }
+        "underscore": "1.9.1"
       }
     },
     "react-bootstrap-table2-filter": {
@@ -19144,7 +19143,7 @@
       "requires": {
         "@babel/code-frame": "7.10.4",
         "address": "1.1.2",
-        "browserslist": "^4.17.6",
+        "browserslist": "4.14.2",
         "chalk": "2.4.2",
         "cross-spawn": "7.0.3",
         "detect-port-alt": "1.1.6",
@@ -19155,15 +19154,15 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "^9.0.6",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
-        "loader-utils": "2.0.4",
+        "loader-utils": "2.0.0",
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
         "react-error-overlay": "^6.0.9",
         "recursive-readdir": "2.2.2",
-        "shell-quote": ">=1.7.3",
+        "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
         "text-table": "0.2.0"
       },
@@ -19177,7 +19176,9 @@
           }
         },
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.14.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
+          "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
           "requires": {
             "caniuse-lite": "^1.0.30001125",
             "electron-to-chromium": "^1.3.564",
@@ -19220,29 +19221,19 @@
             "slash": "^3.0.0"
           }
         },
-        "immer": {
-          "version": "^9.0.6"
-        },
         "json5": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
-          },
-          "dependencies": {
-            "json5": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-              "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
-            }
+            "json5": "^2.1.2"
           }
         },
         "node-releases": {
@@ -19267,9 +19258,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-        },
-        "shell-quote": {
-          "version": ">=1.7.3"
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -19374,7 +19362,7 @@
         "paginator": "^1.0.0",
         "prop-types": "15.x.x - 16.x.x",
         "react": "15.x.x - 16.x.x",
-        "tar": "^6.1.11"
+        "tar": "2.2.2"
       },
       "dependencies": {
         "react": {
@@ -19386,9 +19374,6 @@
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2"
           }
-        },
-        "tar": {
-          "version": "^6.1.11"
         }
       }
     },
@@ -19611,7 +19596,7 @@
         "resolve": "1.18.1",
         "resolve-url-loader": "^3.1.2",
         "sass-loader": "^10.0.5",
-        "semver": "7.5.3",
+        "semver": "7.3.2",
         "style-loader": "1.3.0",
         "terser-webpack-plugin": "4.2.3",
         "ts-pnp": "1.2.0",
@@ -19630,11 +19615,6 @@
             "is-core-module": "^2.0.0",
             "path-parse": "^1.0.6"
           }
-        },
-        "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
         }
       }
     },
@@ -19816,13 +19796,13 @@
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
-        "minimatch": "3.0.5"
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -20017,7 +19997,9 @@
           },
           "dependencies": {
             "nth-check": {
-              "version": "^2.0.1",
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+              "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
               "requires": {
                 "boolbase": "^1.0.0"
               }
@@ -20055,7 +20037,9 @@
           }
         },
         "nth-check": {
-          "version": "^2.0.1",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+          "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
           "requires": {
             "boolbase": "^1.0.0"
           }
@@ -20155,7 +20139,7 @@
         "compose-function": "3.0.3",
         "convert-source-map": "1.7.0",
         "es6-iterator": "2.0.3",
-        "loader-utils": "2.0.4",
+        "loader-utils": "^1.2.3",
         "postcss": "7.0.36",
         "rework": "1.0.1",
         "rework-visit": "1.0.0",
@@ -20181,19 +20165,19 @@
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^1.0.1"
           },
           "dependencies": {
             "json5": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-              "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+              "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
               "requires": {
                 "minimist": "^1.2.0"
               }
@@ -20599,10 +20583,10 @@
       "integrity": "sha512-aX/iJZTTpNUNx/OSYzo2KsjIUQHqvWsAhhUijFjAPdZTEhstjZI9zTNvkTTwsx+uNUJqUwOw5gacxQMx4hJxGQ==",
       "requires": {
         "klona": "^2.0.4",
-        "loader-utils": "2.0.4",
+        "loader-utils": "^2.0.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.0.0",
-        "semver": "7.5.3"
+        "semver": "^7.3.2"
       },
       "dependencies": {
         "loader-utils": {
@@ -20612,7 +20596,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -20708,18 +20692,13 @@
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
       "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
       "requires": {
-        "node-forge": "^1.2.1"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "^1.2.1"
-        }
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -20912,7 +20891,9 @@
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
     },
     "shell-quote": {
-      "version": ">=1.7.3"
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -21197,7 +21178,7 @@
         "btoa": "^1.2.1",
         "chalk": "^4.1.0",
         "convert-source-map": "^1.7.0",
-        "ejs": ">=3.1.7",
+        "ejs": "^3.1.5",
         "escape-html": "^1.0.3",
         "glob": "^7.1.6",
         "gzip-size": "^6.0.0",
@@ -21249,7 +21230,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "ejs": {
-          "version": ">=3.1.7",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+          "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
           "requires": {
             "jake": "^10.8.5"
           }
@@ -21703,7 +21686,7 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
       "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
       "requires": {
-        "loader-utils": "2.0.4",
+        "loader-utils": "^2.0.0",
         "schema-utils": "^2.7.0"
       },
       "dependencies": {
@@ -21714,7 +21697,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -21736,13 +21719,15 @@
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
       "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "requires": {
-        "browserslist": "^4.17.6",
+        "browserslist": "^4.0.0",
         "postcss": "^7.0.0",
         "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "^4.17.6",
+          "version": "4.21.9",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+          "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
           "requires": {
             "caniuse-lite": "^1.0.30001503",
             "electron-to-chromium": "^1.4.431",
@@ -21918,7 +21903,9 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "^6.1.11",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "requires": {
         "block-stream": "*",
         "fstream": "^1.0.12",
@@ -22038,13 +22025,13 @@
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
-            "semver": "7.5.3"
+            "semver": "^6.0.0"
           },
           "dependencies": {
             "semver": {
-              "version": "7.5.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-              "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
             }
           }
         },
@@ -22107,7 +22094,7 @@
       "requires": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
-        "minimatch": "3.0.5"
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -22337,15 +22324,15 @@
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
       "requires": {
         "@types/json5": "^0.0.29",
-        "json5": "2.2.2",
+        "json5": "^1.0.1",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-          "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -22443,9 +22430,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -22621,7 +22608,7 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
       "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
       "requires": {
-        "loader-utils": "2.0.4",
+        "loader-utils": "^2.0.0",
         "mime-types": "^2.1.27",
         "schema-utils": "^3.0.0"
       },
@@ -22633,7 +22620,7 @@
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^2.1.2"
           },
           "dependencies": {
             "json5": {
@@ -22916,7 +22903,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^6.0.2",
+            "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -22927,7 +22914,9 @@
           },
           "dependencies": {
             "glob-parent": {
-              "version": "^6.0.2",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+              "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
               "optional": true,
               "requires": {
                 "is-glob": "^3.1.0",
@@ -22977,7 +22966,9 @@
           "optional": true
         },
         "glob-parent": {
-          "version": "^6.0.2",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
@@ -23101,7 +23092,7 @@
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",
-        "loader-utils": "2.0.4",
+        "loader-utils": "^1.2.3",
         "memory-fs": "^0.4.1",
         "micromatch": "^3.1.10",
         "mkdirp": "^0.5.3",
@@ -23232,19 +23223,19 @@
           "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
         },
         "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "2.2.2"
+            "json5": "^1.0.1"
           },
           "dependencies": {
             "json5": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-              "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+              "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
               "requires": {
                 "minimist": "^1.2.0"
               }
@@ -23366,7 +23357,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
       "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
       "requires": {
-        "ansi-html": "^0.0.9",
+        "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",
@@ -23387,7 +23378,7 @@
         "portfinder": "^1.0.26",
         "schema-utils": "^1.0.0",
         "selfsigned": "^1.10.8",
-        "semver": "7.5.3",
+        "semver": "^6.3.0",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.21",
         "sockjs-client": "^1.5.0",
@@ -23402,7 +23393,9 @@
       },
       "dependencies": {
         "ansi-html": {
-          "version": "^0.0.9"
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+          "integrity": "sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA=="
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -23474,7 +23467,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^6.0.2",
+            "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -23485,7 +23478,9 @@
           },
           "dependencies": {
             "glob-parent": {
-              "version": "^6.0.2",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+              "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
               "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
@@ -23569,7 +23564,9 @@
           "optional": true
         },
         "glob-parent": {
-          "version": "^6.0.2",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
@@ -23702,9 +23699,9 @@
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         },
         "string-width": {
           "version": "3.1.0",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This change is to pick up the application type id from the database based on the application type passed from FF submission.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] using unit test
- [ ] testing using graphql playground



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-853-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-853-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)