### PR TITLE
feat: SRS-788 - view application notes

### DIFF
--- a/backend/cats/src/app/cats.module.ts
+++ b/backend/cats/src/app/cats.module.ts
@@ -71,7 +71,8 @@ import { InvoiceV2 } from './entities/invoiceV2.entity';
 import { InvoiceLineItem } from './entities/invoiceLineItem.entity';
 import { InvoiceResolver } from './resolvers/invoice/invoice.resolver';
 import { InvoiceService } from './services/invoice/invoice.service';
-
+import { ApplicationNotesResolver } from './resolvers/application/applicationNotes.resolver';
+import { ApplicationNotesService } from './services/application/applicationNotes.service';
 /**
  * Module for wrapping all functionalities in user microserivce
  */
@@ -151,6 +152,8 @@ import { InvoiceService } from './services/invoice/invoice.service';
     SiteService,
     InvoiceResolver,
     InvoiceService,
+    ApplicationNotesResolver,
+    ApplicationNotesService,
   ],
   controllers: [UserController],
 })

--- a/backend/cats/src/app/dto/applicationNote.dto.ts
+++ b/backend/cats/src/app/dto/applicationNote.dto.ts
@@ -1,0 +1,35 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { ResponseDto } from './response/response.dto';
+
+@ObjectType()
+export class AppNoteDto {
+  @Field(() => Int)
+  id: number;
+
+  @Field(() => Int)
+  applicationId: number;
+
+  @Field()
+  noteDate: string;
+
+  @Field()
+  noteText: string;
+
+  @Field()
+  createdBy: string;
+
+  @Field(() => Date)
+  createdDateTime: Date;
+
+  @Field()
+  updatedBy: string;
+
+  @Field(() => Date)
+  updatedDateTime: Date;
+}
+
+@ObjectType()
+export class ApplicationNotesResponse extends ResponseDto {
+  @Field(() => [AppNoteDto])
+  data: AppNoteDto[];
+}

--- a/backend/cats/src/app/resolvers/application/applicationNotes.resolver.spec.ts
+++ b/backend/cats/src/app/resolvers/application/applicationNotes.resolver.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApplicationNotesResolver } from './applicationNotes.resolver';
+import { ApplicationNotesService } from '../../services/application/applicationNotes.service';
+import { GenericResponseProvider } from '../../dto/response/genericResponseProvider';
+import { HttpStatus } from '@nestjs/common';
+import { LoggerService } from '../../logger/logger.service';
+import { AppNote } from '../../entities/appNote.entity';
+
+describe('ApplicationNotesResolver', () => {
+  let resolver: ApplicationNotesResolver;
+  let service: ApplicationNotesService;
+  let responseProvider: GenericResponseProvider<any>;
+
+  const mockNoteData = [
+    {
+      id: 1,
+      applicationId: 123,
+      noteDate: '2023-01-01',
+      noteText: 'Test note',
+      createdBy: 'Test User',
+      createdDateTime: new Date(),
+      updatedBy: 'Test User',
+      updatedDateTime: new Date(),
+    },
+  ] as AppNote[];
+
+  const mockResponse = {
+    message: 'Success',
+    statusCode: HttpStatus.OK,
+    success: true,
+    data: mockNoteData,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationNotesResolver,
+        {
+          provide: ApplicationNotesService,
+          useValue: {
+            getApplicationNotesByApplicationId: jest.fn(),
+          },
+        },
+        {
+          provide: GenericResponseProvider,
+          useValue: {
+            createResponse: jest.fn(),
+          },
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<ApplicationNotesResolver>(ApplicationNotesResolver);
+    service = module.get<ApplicationNotesService>(ApplicationNotesService);
+    responseProvider = module.get<GenericResponseProvider<any>>(
+      GenericResponseProvider,
+    );
+  });
+
+  describe('getApplicationNotesByApplicationId', () => {
+    it('should call getApplicationNotesByApplicationId service method', async () => {
+      jest
+        .spyOn(service, 'getApplicationNotesByApplicationId')
+        .mockResolvedValue(mockNoteData);
+      jest
+        .spyOn(responseProvider, 'createResponse')
+        .mockReturnValue(mockResponse);
+
+      const mockApplicationId = 123;
+
+      const result = await resolver.getApplicationNotesByApplicationId(
+        mockApplicationId,
+      );
+
+      expect(service.getApplicationNotesByApplicationId).toHaveBeenCalledWith(
+        mockApplicationId,
+      );
+      expect(responseProvider.createResponse).toHaveBeenCalledWith(
+        'Application notes fetched successfully',
+        HttpStatus.OK,
+        true,
+        mockNoteData,
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/backend/cats/src/app/resolvers/application/applicationNotes.resolver.ts
+++ b/backend/cats/src/app/resolvers/application/applicationNotes.resolver.ts
@@ -1,0 +1,50 @@
+import { Args, Int, Query, Resolver } from '@nestjs/graphql';
+import { HttpStatus, UsePipes } from '@nestjs/common';
+import { LoggerService } from '../../logger/logger.service';
+import { GenericResponseProvider } from '../../dto/response/genericResponseProvider';
+import { GenericValidationPipe } from '../../utils/validations/genericValidationPipe';
+import { ApplicationNotesService } from '../../services/application/applicationNotes.service';
+import { AppNote } from '../../entities/appNote.entity';
+import {
+  AppNoteDto,
+  ApplicationNotesResponse,
+} from '../../dto/applicationNote.dto';
+
+@Resolver(() => AppNoteDto)
+export class ApplicationNotesResolver {
+  constructor(
+    private readonly applicationNotesService: ApplicationNotesService,
+    private readonly genericResponseProvider: GenericResponseProvider<
+      AppNote[]
+    >,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  @Query(() => ApplicationNotesResponse, {
+    name: 'getApplicationNotesByApplicationId',
+  })
+  @UsePipes(new GenericValidationPipe())
+  async getApplicationNotesByApplicationId(
+    @Args('applicationId', { type: () => Int }) applicationId: number,
+  ) {
+    this.loggerService.log(
+      `ApplicationNotesResolver.getApplicationNotesByApplicationId: Getting notes for application ID ${applicationId}`,
+    );
+
+    const result =
+      await this.applicationNotesService.getApplicationNotesByApplicationId(
+        applicationId,
+      );
+
+    this.loggerService.log(
+      `ApplicationNotesResolver.getApplicationNotesByApplicationId: ${result.length} notes found.`,
+    );
+
+    return this.genericResponseProvider.createResponse(
+      'Application notes fetched successfully',
+      HttpStatus.OK,
+      true,
+      result,
+    );
+  }
+}

--- a/backend/cats/src/app/services/application/applicationNotes.service.spec.ts
+++ b/backend/cats/src/app/services/application/applicationNotes.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LoggerService } from '../../logger/logger.service';
+import { ApplicationNotesService } from './applicationNotes.service';
+import { AppNote } from '../../entities/appNote.entity';
+import { HttpException } from '@nestjs/common';
+
+describe('ApplicationNotesService', () => {
+  let service: ApplicationNotesService;
+  let appNoteRepository: Repository<AppNote>;
+
+  const mockNotes = [
+    {
+      id: 1,
+      applicationId: 123,
+      noteDate: '2023-01-01',
+      noteText: 'Test note 1',
+      rowVersionCount: 1,
+      createdBy: 'Test User',
+      createdDateTime: new Date(),
+      updatedBy: 'Test User',
+      updatedDateTime: new Date(),
+    },
+    {
+      id: 2,
+      applicationId: 123,
+      noteDate: '2023-01-02',
+      noteText: 'Test note 2',
+      rowVersionCount: 1,
+      createdBy: 'Test User',
+      createdDateTime: new Date(),
+      updatedBy: 'Test User',
+      updatedDateTime: new Date(),
+    },
+  ] as AppNote[];
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationNotesService,
+        {
+          provide: getRepositoryToken(AppNote),
+          useClass: Repository,
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApplicationNotesService>(ApplicationNotesService);
+    appNoteRepository = module.get<Repository<AppNote>>(
+      getRepositoryToken(AppNote),
+    );
+  });
+
+  describe('getApplicationNotesByApplicationId', () => {
+    it('should return notes for an application', async () => {
+      jest.spyOn(appNoteRepository, 'find').mockResolvedValue(mockNotes);
+
+      const result = await service.getApplicationNotesByApplicationId(123);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(2);
+      expect(result[0].noteText).toBe('Test note 1');
+      expect(result[1].noteText).toBe('Test note 2');
+      expect(appNoteRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            applicationId: 123,
+          },
+        }),
+      );
+    });
+
+    it('should throw an exception when find operation fails', async () => {
+      jest.spyOn(appNoteRepository, 'find').mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await expect(
+        service.getApplicationNotesByApplicationId(123),
+      ).rejects.toThrow(HttpException);
+    });
+  });
+});

--- a/backend/cats/src/app/services/application/applicationNotes.service.ts
+++ b/backend/cats/src/app/services/application/applicationNotes.service.ts
@@ -1,0 +1,50 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { plainToInstance } from 'class-transformer';
+import { Repository } from 'typeorm';
+
+import { AppNote } from '../../entities/appNote.entity';
+import { LoggerService } from '../../logger/logger.service';
+
+@Injectable()
+export class ApplicationNotesService {
+  constructor(
+    @InjectRepository(AppNote)
+    private readonly appNoteRepository: Repository<AppNote>,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  async getApplicationNotesByApplicationId(
+    applicationId: number,
+  ): Promise<AppNote[]> {
+    try {
+      this.loggerService.log(
+        `ApplicationNotesService.getApplicationNotesByApplicationId: Getting notes for application ID ${applicationId}`,
+      );
+
+      const notes = await this.appNoteRepository.find({
+        where: {
+          applicationId: applicationId,
+        },
+        order: {
+          noteDate: 'DESC',
+        },
+      });
+
+      this.loggerService.log(
+        `ApplicationNotesService.getApplicationNotesByApplicationId: ${notes.length} notes found.`,
+      );
+
+      return plainToInstance(AppNote, notes);
+    } catch (error) {
+      this.loggerService.error(
+        `ApplicationNotesService.getApplicationNotesByApplicationId: Error getting notes for application ID ${applicationId}`,
+        error,
+      );
+      throw new HttpException(
+        error.message || 'Failed to fetch application notes',
+        error.status || HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+}

--- a/cats-frontend/src/app/components/table/TableColumn.ts
+++ b/cats-frontend/src/app/components/table/TableColumn.ts
@@ -35,7 +35,7 @@ export class TableColumn {
     public columnSize?: ColumnSize,
     public stickyCol?: boolean,
     public customHeaderCss?: string,
-    public renderCell?: (value: any) => ReactNode,
+    public renderCell?: (value: any, row: any) => ReactNode,
   ) {
     this.dynamicColumn = dynamicColumn ?? false;
   }

--- a/cats-frontend/src/app/components/table/body/TableBody.tsx
+++ b/cats-frontend/src/app/components/table/body/TableBody.tsx
@@ -494,8 +494,10 @@ const TableBody: FC<TableBodyProps> = ({
     let cellValue: string | ReactNode;
 
     if (column.renderCell && typeof column.renderCell === 'function') {
-      cellValue = cellData.map((data: any, i: number) => (
-        <React.Fragment key={i}>{column.renderCell!(data)}</React.Fragment>
+      cellValue = cellData.map((cellData: any, i: number) => (
+        <React.Fragment key={i}>
+          {column.renderCell!(cellData, data[rowIndex])}
+        </React.Fragment>
       ));
     } else {
       cellValue = cellData.join(' ');

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.generated.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.generated.tsx
@@ -1,0 +1,62 @@
+import * as Types from '../../../../../../generated/types';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type GetApplicationNotesByApplicationIdQueryVariables = Types.Exact<{
+  applicationId: Types.Scalars['Int']['input'];
+}>;
+
+
+export type GetApplicationNotesByApplicationIdQuery = { __typename?: 'Query', getApplicationNotesByApplicationId: { __typename?: 'ApplicationNotesResponse', data: Array<{ __typename?: 'AppNoteDto', id: number, applicationId: number, noteDate: string, noteText: string, createdBy: string, createdDateTime: any, updatedBy: string, updatedDateTime: any }> } };
+
+
+export const GetApplicationNotesByApplicationIdDocument = gql`
+    query getApplicationNotesByApplicationId($applicationId: Int!) {
+  getApplicationNotesByApplicationId(applicationId: $applicationId) {
+    data {
+      id
+      applicationId
+      noteDate
+      noteText
+      createdBy
+      createdDateTime
+      updatedBy
+      updatedDateTime
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetApplicationNotesByApplicationIdQuery__
+ *
+ * To run a query within a React component, call `useGetApplicationNotesByApplicationIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetApplicationNotesByApplicationIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetApplicationNotesByApplicationIdQuery({
+ *   variables: {
+ *      applicationId: // value for 'applicationId'
+ *   },
+ * });
+ */
+export function useGetApplicationNotesByApplicationIdQuery(baseOptions: Apollo.QueryHookOptions<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables> & ({ variables: GetApplicationNotesByApplicationIdQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables>(GetApplicationNotesByApplicationIdDocument, options);
+      }
+export function useGetApplicationNotesByApplicationIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables>(GetApplicationNotesByApplicationIdDocument, options);
+        }
+export function useGetApplicationNotesByApplicationIdSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables>(GetApplicationNotesByApplicationIdDocument, options);
+        }
+export type GetApplicationNotesByApplicationIdQueryHookResult = ReturnType<typeof useGetApplicationNotesByApplicationIdQuery>;
+export type GetApplicationNotesByApplicationIdLazyQueryHookResult = ReturnType<typeof useGetApplicationNotesByApplicationIdLazyQuery>;
+export type GetApplicationNotesByApplicationIdSuspenseQueryHookResult = ReturnType<typeof useGetApplicationNotesByApplicationIdSuspenseQuery>;
+export type GetApplicationNotesByApplicationIdQueryResult = Apollo.QueryResult<GetApplicationNotesByApplicationIdQuery, GetApplicationNotesByApplicationIdQueryVariables>;

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.graphql
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.graphql
@@ -1,0 +1,14 @@
+query getApplicationNotesByApplicationId($applicationId: Int!) {
+  getApplicationNotesByApplicationId(applicationId: $applicationId) {
+    data {
+      id
+      applicationId
+      noteDate
+      noteText
+      createdBy
+      createdDateTime
+      updatedBy
+      updatedDateTime
+    }
+  }
+}

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.module.css
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.module.css
@@ -1,0 +1,12 @@
+.editNoteButton {
+  display: flex;
+  align-items: center;
+  gap: var(--layout-padding-small);
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  justify-content: center;
+  color: var(--theme-primary-blue);
+}

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/Notes.tsx
@@ -1,7 +1,109 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  useGetApplicationNotesByApplicationIdQuery,
+  GetApplicationNotesByApplicationIdQuery,
+} from './Notes.generated';
+import Widget from '@cats/components/widget/Widget';
+import { Button } from '@cats/components/button/Button';
+import { Plus } from '@cats/components/common/icon';
+import { RequestStatus } from '@cats/helpers/requests/status';
+import { getApplicationNotesColumns } from './applicationNotesTableConfig';
+
+export type Note =
+  GetApplicationNotesByApplicationIdQuery['getApplicationNotesByApplicationId']['data'][number];
+
+type SortColumn = {
+  column: ReturnType<
+    typeof getApplicationNotesColumns
+  >[number]['graphQLPropertyName'];
+  direction: 'asc' | 'desc';
+};
+
+const sortNotes = (data: Note[], sortColumn: SortColumn | null) => {
+  if (!sortColumn) return data;
+
+  return data.toSorted((a, b) => {
+    if (sortColumn.column === 'noteDate') {
+      return sortColumn.direction === 'asc'
+        ? new Date(a.noteDate).getTime() - new Date(b.noteDate).getTime()
+        : new Date(b.noteDate).getTime() - new Date(a.noteDate).getTime();
+    }
+    if (sortColumn.column === 'createdBy') {
+      const aDisplayName = a.updatedBy || a.createdBy;
+      const bDisplayName = b.updatedBy || b.createdBy;
+      return sortColumn.direction === 'asc'
+        ? aDisplayName.localeCompare(bDisplayName)
+        : bDisplayName.localeCompare(aDisplayName);
+    }
+    if (sortColumn.column === 'noteText') {
+      return sortColumn.direction === 'asc'
+        ? a.noteText.localeCompare(b.noteText)
+        : b.noteText.localeCompare(a.noteText);
+    }
+    return 0;
+  });
+};
+
 export const Notes = () => {
+  const { id: applicationId } = useParams();
+  const { data, loading } = useGetApplicationNotesByApplicationIdQuery({
+    variables: {
+      applicationId: parseInt(applicationId ?? '0', 10),
+    },
+    skip: !applicationId,
+  });
+
+  const [selectedRows, setSelectedRows] = useState<Set<Note['id']>>(new Set());
+
+  const [sortColumn, setSortColumn] = useState<SortColumn | null>(null);
+  const tableSortHandler = (
+    column: ReturnType<typeof getApplicationNotesColumns>[number],
+    ascSort: boolean,
+  ) => {
+    setSortColumn({
+      column: column.graphQLPropertyName,
+      direction: ascSort ? 'asc' : 'desc',
+    });
+  };
+
+  const sortedData = sortNotes(
+    data?.getApplicationNotesByApplicationId.data || [],
+    sortColumn,
+  );
+
+  const tableChangeHandler = (event: any) => {
+    if (event.property === 'select_row') {
+      const row = event.row as Note;
+      setSelectedRows((prev) => {
+        const ids = new Set(prev);
+        ids.has(row.id) ? ids.delete(row.id) : ids.add(row.id);
+        return ids;
+      });
+    }
+  };
+
   return (
     <div>
-      <p>Notes Page</p>
+      <Widget
+        primaryKeycolumnName="id"
+        allowRowsSelect
+        tableData={sortedData}
+        title={'Notes'}
+        tableColumns={getApplicationNotesColumns({
+          onEdit: (row) => console.log(row, 'TODO'),
+        })}
+        tableIsLoading={loading ? RequestStatus.loading : RequestStatus.idle}
+        changeHandler={tableChangeHandler}
+        sortHandler={tableSortHandler}
+      >
+        <div className="d-flex gap-2 flex-wrap">
+          <Button variant="secondary">
+            <Plus />
+            New Note
+          </Button>
+        </div>
+      </Widget>
     </div>
   );
 };

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/applicationNotesTableConfig.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appNotes/applicationNotesTableConfig.tsx
@@ -1,0 +1,58 @@
+import { ColumnSize } from '@cats/components/table/TableColumn';
+import { FormFieldType } from '@cats/components/input-controls/IFormField';
+import { TableColumn } from '@cats/components/table/TableColumn';
+import { formatDateUTC } from '@cats/helpers/utility';
+import { PencilIcon } from '@cats/components/common/icon';
+import styles from './Notes.module.css';
+import type { Note } from './Notes';
+
+export const getApplicationNotesColumns = ({
+  onEdit,
+}: {
+  onEdit: (id: Note) => void;
+}): TableColumn[] => [
+  {
+    id: 1,
+    displayName: 'Date',
+    active: true,
+    graphQLPropertyName: 'noteDate',
+    displayType: { type: FormFieldType.Label },
+    columnSize: ColumnSize.Small,
+    renderCell: (value: Note['noteDate']) => {
+      return formatDateUTC(value, 'EEE MMM dd yyyy');
+    },
+  },
+  {
+    id: 2,
+    displayName: 'User',
+    active: true,
+    graphQLPropertyName: 'createdBy',
+    displayType: { type: FormFieldType.Label },
+    renderCell: (_, row: Note) => {
+      return row.updatedBy || row.createdBy;
+    },
+  },
+  {
+    id: 3,
+    displayName: 'Note',
+    active: true,
+    graphQLPropertyName: 'noteText',
+    displayType: { type: FormFieldType.Label },
+  },
+  {
+    id: 4,
+    displayName: 'Actions',
+    active: true,
+    dynamicColumn: true,
+    graphQLPropertyName: 'id',
+    displayType: { type: FormFieldType.Label },
+    columnSize: ColumnSize.XtraSmall,
+    renderCell: (_, row: Note) => {
+      return (
+        <button className={styles.editNoteButton} onClick={() => onEdit(row)}>
+          <PencilIcon /> Edit
+        </button>
+      );
+    },
+  },
+];

--- a/cats-frontend/src/generated/types.ts
+++ b/cats-frontend/src/generated/types.ts
@@ -30,6 +30,18 @@ export type AddHousingInputDto = {
   relatedApplicationIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export type AppNoteDto = {
+  __typename?: 'AppNoteDto';
+  applicationId: Scalars['Int']['output'];
+  createdBy: Scalars['String']['output'];
+  createdDateTime: Scalars['DateTime']['output'];
+  id: Scalars['Int']['output'];
+  noteDate: Scalars['String']['output'];
+  noteText: Scalars['String']['output'];
+  updatedBy: Scalars['String']['output'];
+  updatedDateTime: Scalars['DateTime']['output'];
+};
+
 export enum AppParticipantFilter {
   All = 'ALL',
   Main = 'MAIN'
@@ -68,6 +80,15 @@ export type ApplicationHousingDto = {
 export type ApplicationHousingResponse = {
   __typename?: 'ApplicationHousingResponse';
   data: Array<ApplicationHousingDto>;
+  httpStatusCode?: Maybe<Scalars['Int']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
+  timestamp?: Maybe<Scalars['String']['output']>;
+};
+
+export type ApplicationNotesResponse = {
+  __typename?: 'ApplicationNotesResponse';
+  data: Array<AppNoteDto>;
   httpStatusCode?: Maybe<Scalars['Int']['output']>;
   message?: Maybe<Scalars['String']['output']>;
   success?: Maybe<Scalars['Boolean']['output']>;
@@ -360,6 +381,7 @@ export type Query = {
   getAppParticipantsByAppId: AppParticipantsResponse;
   getApplicationDetailsById: ApplicationDetailsResponse;
   getApplicationHousingByApplicationId: ApplicationHousingResponse;
+  getApplicationNotesByApplicationId: ApplicationNotesResponse;
   getHousingTypes: HousingTypeResponse;
   getInvoicesByApplicationId: InvoicesByApplicationIdResponse;
   getOrganizations: DropdownResponse;
@@ -389,6 +411,11 @@ export type QueryGetApplicationDetailsByIdArgs = {
 
 
 export type QueryGetApplicationHousingByApplicationIdArgs = {
+  applicationId: Scalars['Int']['input'];
+};
+
+
+export type QueryGetApplicationNotesByApplicationIdArgs = {
   applicationId: Scalars['Int']['input'];
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR adds an API endpoint to fetch application notes and the table to display them on the FE.

Create / Update / Delete operations will be added in the next PR.

Fixes [SRS-788](https://env-epd.atlassian.net/browse/SRS-788)

Demo: 
<img width="1318" alt="image" src="https://github.com/user-attachments/assets/6acc71d7-4f36-413a-9fb1-625f9b8b5524" />

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test locally by navigating to `/applications/:id?tab=notes`

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged
