### PR TITLE
chore: SRS-917 - add auth mock mode, improve auth error handling

### DIFF
--- a/backend/cats/src/app.module.ts
+++ b/backend/cats/src/app.module.ts
@@ -17,6 +17,8 @@ import {
 import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { CustomExceptionFilter } from './app/filters/customExceptionFilters';
+import { MockAuthGuard } from './app/guards/mock-auth.guard';
+import { GraphQLAuthExceptionFilter } from './app/filters/graphql-exception.filter';
 
 /**
  * Application Module Wrapping All Functionality For User Micro Service
@@ -68,7 +70,7 @@ import { CustomExceptionFilter } from './app/filters/customExceptionFilters';
     AppService,
     {
       provide: APP_GUARD,
-      useClass: AuthGuard,
+      useClass: process.env.MOCK_AUTH === 'true' ? MockAuthGuard : AuthGuard,
     },
     {
       provide: APP_GUARD,
@@ -81,6 +83,10 @@ import { CustomExceptionFilter } from './app/filters/customExceptionFilters';
     {
       provide: APP_FILTER,
       useClass: CustomExceptionFilter,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: GraphQLAuthExceptionFilter,
     },
   ],
 })

--- a/backend/cats/src/app/filters/graphql-exception.filter.ts
+++ b/backend/cats/src/app/filters/graphql-exception.filter.ts
@@ -1,0 +1,21 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  UnauthorizedException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { GqlArgumentsHost } from '@nestjs/graphql';
+
+// This filter allows us to actionable authentication erorrs
+// istead of messages like "Cannot return null for non-nullable field whatever.data"
+@Catch(UnauthorizedException, ForbiddenException)
+export class GraphQLAuthExceptionFilter implements ExceptionFilter {
+  catch(
+    exception: UnauthorizedException | ForbiddenException,
+    host: ArgumentsHost,
+  ) {
+    const gqlHost = GqlArgumentsHost.create(host);
+    throw exception;
+  }
+}

--- a/backend/cats/src/app/filters/graphql-exception.filter.ts
+++ b/backend/cats/src/app/filters/graphql-exception.filter.ts
@@ -16,6 +16,18 @@ export class GraphQLAuthExceptionFilter implements ExceptionFilter {
     host: ArgumentsHost,
   ) {
     const gqlHost = GqlArgumentsHost.create(host);
-    throw exception;
+    const errorResponse = {
+      message: exception.message,
+      extensions: {
+        code: exception instanceof UnauthorizedException ? 'UNAUTHORIZED' : 'FORBIDDEN',
+        exception: {
+          name: exception.name,
+          stacktrace: exception.stack,
+        },
+      },
+    };
+    throw new GraphQLError(errorResponse.message, {
+      extensions: errorResponse.extensions,
+    });
   }
 }

--- a/backend/cats/src/app/guards/mock-auth.guard.ts
+++ b/backend/cats/src/app/guards/mock-auth.guard.ts
@@ -1,0 +1,29 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+
+const mockUser = {
+  sub: 'mock-user-id',
+  preferred_username: 'devuser',
+  name: 'devuser',
+  givenName: 'devuser',
+  email: 'devuser@example.com',
+  roles: ['developer'],
+  identity_provider: 'idir',
+};
+@Injectable()
+export class MockAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    // For REST
+    const req = context.switchToHttp().getRequest();
+    if (req) {
+      req.user = mockUser;
+    }
+
+    // For GraphQL
+    const gqlCtx = context.getArgByIndex(2);
+    if (gqlCtx && gqlCtx.req) {
+      gqlCtx.req.user = mockUser;
+    }
+
+    return true; // Always allow
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

With our current keycloak setup, it's difficult to develop and test graphql queries/mutations without also building the front-end that uses them because almost every query requires user authentication. What I and other devs on the team tend to do is commenting out the auth guards when you need to call the API from the sandbox/postman/some-other-client. This approach has two major issues: 
1. It's easy to forget to put the guards back
2. You lose the access to the `@AuthenticatedUser` object

This PR makes two keys changes:

### 1.  **Mock Authentication Mode for Development**
-  Added a `MockAuthGuard` that injects a mock user object into the request/context, allowing the app to bypass Keycloak authentication when the environment variable `MOCK_AUTH=true` is set.
- Updated AppModule to use MockAuthGuard as the global APP_GUARD when in mock mode, otherwise defaulting to the standard AuthGuard.

This enables seamless development and testing without requiring authentication or even a live Keycloak server.
<img width="991" alt="image" src="https://github.com/user-attachments/assets/13878728-88f6-4630-b127-f019ab372237" />

### 2. Improved GraphQL Authentication Error Handling
- Added a `GraphQLAuthExceptionFilter` that catches `UnauthorizedException` and `ForbiddenException` errors thrown by authentication guards.
- Unauthenticated clients will now get proper GraphQL errors, rather than generic "Cannot return null for non-nullable field" messages.

**Before**
<img width="812" alt="image" src="https://github.com/user-attachments/assets/eadc3ad9-6d9f-4f0e-a187-6da4e5df7b9d" />

**After**
<img width="443" alt="image" src="https://github.com/user-attachments/assets/a5c06060-3f44-4ab0-acf6-41e1058e4654" />

Fixes [SRS-917](https://env-epd.atlassian.net/browse/SRS-917)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Add `MOCK_AUTH=true` to your .env file and restart the server. At this point, you should be able to make graphql requests with your client of choice.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-883-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-883-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-883-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-883-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)