### PR TITLE
chore: SRS-918 surface operation names in Graphql requests

### DIFF
--- a/cats-frontend/src/apollo.ts
+++ b/cats-frontend/src/apollo.ts
@@ -26,15 +26,14 @@ const authLink = setContext((_, { headers }) => {
 
 // Custom link to append operation name to the URI
 const operationNameLink = new ApolloLink((operation, forward) => {
-  let uri = `${API}${GRAPHQL}`;
+  const uri = new URL(`${API}${GRAPHQL}`);
   const operationName = operation.operationName;
 
-  // Append ?op=operationName or &op=operationName if there are already query params
-  const hasQuery = uri.includes('?');
-  uri = hasQuery ? `${uri}&op=${operationName}` : `${uri}?op=${operationName}`;
+  // Append the 'op' parameter using the URL object
+  uri.searchParams.append('op', operationName);
 
   operation.setContext(({ headers = {} }) => ({
-    uri,
+    uri: uri.toString(),
     headers,
   }));
   return forward(operation);

--- a/cats-frontend/src/apollo.ts
+++ b/cats-frontend/src/apollo.ts
@@ -1,0 +1,46 @@
+import {
+  ApolloClient,
+  InMemoryCache,
+  createHttpLink,
+  ApolloLink,
+} from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+
+import { getUser } from './app/helpers/utility';
+import { API, GRAPHQL } from './app/helpers/endpoints';
+
+const httpLink = createHttpLink({
+  uri: `${API}${GRAPHQL}`,
+});
+
+const authLink = setContext((_, { headers }) => {
+  const user = getUser();
+
+  return {
+    headers: {
+      ...headers,
+      authorization: user?.access_token ? `Bearer ${user.access_token}` : '',
+    },
+  };
+});
+
+// Custom link to append operation name to the URI
+const operationNameLink = new ApolloLink((operation, forward) => {
+  // Get the current URI from context or httpLink
+  let uri = `${API}${GRAPHQL}`;
+  const operationName = operation.operationName;
+  // Append ?op=operationName or &op=operationName if there are already query params
+  const hasQuery = uri.includes('?');
+  uri = hasQuery ? `${uri}&op=${operationName}` : `${uri}?op=${operationName}`;
+  // Set the new URI in the context for httpLink to use
+  operation.setContext(({ headers = {} }) => ({
+    uri,
+    headers,
+  }));
+  return forward(operation);
+});
+
+export const apolloClientInstance = new ApolloClient({
+  link: ApolloLink.from([operationNameLink, authLink.concat(httpLink)]),
+  cache: new InMemoryCache(),
+});

--- a/cats-frontend/src/apollo.ts
+++ b/cats-frontend/src/apollo.ts
@@ -26,13 +26,13 @@ const authLink = setContext((_, { headers }) => {
 
 // Custom link to append operation name to the URI
 const operationNameLink = new ApolloLink((operation, forward) => {
-  // Get the current URI from context or httpLink
   let uri = `${API}${GRAPHQL}`;
   const operationName = operation.operationName;
+
   // Append ?op=operationName or &op=operationName if there are already query params
   const hasQuery = uri.includes('?');
   uri = hasQuery ? `${uri}&op=${operationName}` : `${uri}?op=${operationName}`;
-  // Set the new URI in the context for httpLink to use
+
   operation.setContext(({ headers = {} }) => ({
     uri,
     headers,

--- a/cats-frontend/src/index.tsx
+++ b/cats-frontend/src/index.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import {
-  ApolloClient,
-  InMemoryCache,
-  ApolloProvider,
-  createHttpLink,
-} from '@apollo/client';
-import { setContext } from '@apollo/client/link/context';
+import { ApolloProvider } from '@apollo/client';
 
 import './index.css';
 import reportWebVitals from './reportWebVitals';
@@ -18,32 +12,11 @@ import { UserManagerSettings } from 'oidc-client-ts';
 import { getClientSettings } from './app/auth/UserManagerSetting';
 import { RouterProvider } from 'react-router-dom';
 import siteRouter from './app/routes/Routes';
-import { getUser } from './app/helpers/utility';
-import { API, GRAPHQL } from './app/helpers/endpoints';
+import { apolloClientInstance } from './apollo';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLDivElement,
 );
-
-const httpLink = createHttpLink({
-  uri: `${API}${GRAPHQL}`,
-});
-
-const authLink = setContext((_, { headers }) => {
-  const user = getUser();
-
-  return {
-    headers: {
-      ...headers,
-      authorization: user?.access_token ? `Bearer ${user.access_token}` : '',
-    },
-  };
-});
-
-const client = new ApolloClient({
-  link: authLink.concat(httpLink),
-  cache: new InMemoryCache(),
-});
 
 // This is a required callback for proper auth experience. From the `react-oidc-context` docs:
 // "You must provide an implementation of onSigninCallback to oidcConfig to remove the payload from the URL upon successful login.
@@ -56,7 +29,7 @@ const authOptions: UserManagerSettings = getClientSettings();
 root.render(
   <React.StrictMode>
     <AuthProvider {...authOptions} onSigninCallback={onSigninCallback}>
-      <ApolloProvider client={client}>
+      <ApolloProvider client={apolloClientInstance}>
         <Provider store={store}>
           <RouterProvider router={siteRouter} />
         </Provider>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Has this ever happened to you? You're trying to debug a graphql query made by your front end, so you open the network tab of your dev tools and all you see is 

<img width="551" alt="Screenshot 2025-04-25 at 5 11 48 PM" src="https://github.com/user-attachments/assets/68ab89f8-fccc-42a1-8cb9-6eadf1df93fb" />

And then you need to click each request to find the one you're looking for? Well not anymore! 

<img width="551" alt="Screenshot 2025-04-25 at 5 12 19 PM" src="https://github.com/user-attachments/assets/f5553bb4-50b9-486c-853a-853558bcb016" />

This change appends the operation's name so that the query/mutation you're looking for is identifiable at a glance

**Note**: I only added this to requests initiated by Apollo Client. While it is possible to use a similar pattern in axios-based queries, I didn't add it because:
1. It's not possible to infer the operation's name at runtime. We'd need pass the name to every call to axios instance, which results in a lot more code
2. Given the alternatives, I really don't think we should continue using the axios-based pattern.
3. I'm not super familiar with the use cases for those queries.

Fixes [SRS-918](https://env-epd.atlassian.net/browse/SRS-918)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check your dev tools!

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-884-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-884-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)