### PR TITLE
feat: SRS-785: API to create, update and get timesheet days

### DIFF
--- a/backend/cats/package-lock.json
+++ b/backend/cats/package-lock.json
@@ -23,6 +23,7 @@
         "axios": "^1.7.9",
         "class-transformer": "^0.5.1",
         "cls-rtracer": "^2.6.3",
+        "date-fns": "^4.1.0",
         "graphql": "^16.6.0",
         "keycloak-connect": "^18.0.2",
         "nest-keycloak-connect": "^1.9.0",
@@ -1402,7 +1403,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -7743,15 +7743,12 @@
       "dev": true
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debounce": {
@@ -12637,8 +12634,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -14303,6 +14299,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/typeorm/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/typeorm/node_modules/mkdirp": {
@@ -15982,7 +15993,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -20846,9 +20856,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "debounce": {
       "version": "1.2.1",
@@ -24493,8 +24503,7 @@
     "regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -25648,6 +25657,14 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "date-fns": {
+          "version": "2.30.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+          "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+          "requires": {
+            "@babel/runtime": "^7.21.0"
           }
         },
         "mkdirp": {

--- a/backend/cats/package.json
+++ b/backend/cats/package.json
@@ -44,6 +44,7 @@
     "axios": "^1.7.9",
     "class-transformer": "^0.5.1",
     "cls-rtracer": "^2.6.3",
+    "date-fns": "^4.1.0",
     "graphql": "^16.6.0",
     "keycloak-connect": "^18.0.2",
     "nest-keycloak-connect": "^1.9.0",

--- a/backend/cats/src/app/cats.module.ts
+++ b/backend/cats/src/app/cats.module.ts
@@ -78,6 +78,9 @@ import { ChesEmailService } from './services/email/chesEmail.service';
 import { HttpModule, HttpService } from '@nestjs/axios';
 import { ApplicationServiceType } from './entities/applicationServiceType.entity';
 import { StaffAssignmentResolver } from './resolvers/assignment/staffAssignment.resolver';
+import { TimesheetDay } from './entities/timesheetDay.entity';
+import { TimesheetDayService } from './services/timesheetDay.service';
+import { TimesheetDayResolver } from './resolvers/timesheetDay.resolver';
 
 /**
  * Module for wrapping all functionalities in user microserivce
@@ -91,6 +94,7 @@ import { StaffAssignmentResolver } from './resolvers/assignment/staffAssignment.
       Application,
       TimesheetWeek,
       TimesheetDetail,
+      TimesheetDay,
       AppExpense,
       AppLandUse,
       LandUse,
@@ -165,6 +169,8 @@ import { StaffAssignmentResolver } from './resolvers/assignment/staffAssignment.
     StaffAssignmentResolver,
     StaffAssignmentService,
     ChesEmailService,
+    TimesheetDayService,
+    TimesheetDayResolver,
   ],
   controllers: [UserController],
 })

--- a/backend/cats/src/app/dto/response/timesheetDayResponse.ts
+++ b/backend/cats/src/app/dto/response/timesheetDayResponse.ts
@@ -1,0 +1,9 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { ResponseDto } from './response.dto';
+import { TimesheetDayDto } from '../timesheetDay.dto';
+
+@ObjectType()
+export class TimesheetDayResponse extends ResponseDto {
+  @Field(() => [TimesheetDayDto])
+  data: TimesheetDayDto[];
+}

--- a/backend/cats/src/app/dto/timesheetDay.dto.ts
+++ b/backend/cats/src/app/dto/timesheetDay.dto.ts
@@ -1,0 +1,95 @@
+import { Field, InputType, Int, ObjectType, Float } from '@nestjs/graphql';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsPositive,
+  IsInt,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ResponseDto } from './response/response.dto';
+
+@ObjectType()
+export class TimesheetDayDto {
+  @Field(() => Int)
+  id: number;
+
+  @Field(() => Int)
+  applicationId: number;
+
+  @Field(() => Int)
+  personId: number;
+
+  @Field()
+  date: Date;
+
+  @Field(() => Float, { nullable: true })
+  hours?: number;
+}
+
+@InputType()
+export class TimesheetDayUpsertInputDto {
+  @Field(() => Int, { nullable: true })
+  @IsOptional()
+  @IsInt()
+  timesheetDayId?: number;
+
+  @Field(() => Int)
+  @IsInt()
+  @IsPositive()
+  @IsNotEmpty()
+  applicationId: number;
+
+  @Field(() => Int)
+  @IsInt()
+  @IsPositive()
+  @IsNotEmpty()
+  personId: number;
+
+  @Field()
+  @IsNotEmpty()
+  date: string;
+
+  @Field(() => Float, { nullable: true })
+  @IsNumber()
+  hours?: number;
+}
+
+@InputType()
+export class UpsertTimesheetDaysInputDto {
+  @Field(() => [TimesheetDayUpsertInputDto])
+  @ValidateNested({ each: true })
+  @Type(() => TimesheetDayUpsertInputDto)
+  entries: TimesheetDayUpsertInputDto[];
+}
+
+@ObjectType()
+export class TimesheetDayResponse extends ResponseDto {
+  @Field(() => [TimesheetDayDto])
+  data: TimesheetDayDto[];
+}
+
+@ObjectType()
+export class PersonWithTimesheetDaysDto {
+  @Field(() => Int)
+  personId: number;
+
+  @Field()
+  firstName: string;
+
+  @Field()
+  lastName: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field(() => [TimesheetDayDto])
+  timesheetDays: TimesheetDayDto[];
+}
+
+@ObjectType()
+export class PersonWithTimesheetDaysResponse extends ResponseDto {
+  @Field(() => [PersonWithTimesheetDaysDto], { nullable: true })
+  data?: PersonWithTimesheetDaysDto[];
+}

--- a/backend/cats/src/app/entities/timesheetDay.entity.ts
+++ b/backend/cats/src/app/entities/timesheetDay.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Application } from './application.entity';
+import { Person } from './person.entity';
+
+@Index('pk_timesheet_day', ['id'], { unique: true })
+@Index('idx_timesheet_day_application_id', ['applicationId'], {})
+@Index('idx_timesheet_day_person_id', ['personId'], {})
+@Entity('timesheet_day')
+export class TimesheetDay {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'id' })
+  id: number;
+
+  @Column('integer', { name: 'application_id' })
+  applicationId: number;
+
+  @Column('integer', { name: 'person_id' })
+  personId: number;
+
+  @Column('date', { name: 'date' })
+  date: string;
+
+  @Column('character varying', {
+    name: 'description',
+    nullable: true,
+    length: 255,
+  })
+  description: string | null;
+
+  @Column('numeric', { name: 'hours', nullable: true, precision: 5, scale: 2 })
+  hours: string | null;
+
+  @Column('character varying', {
+    name: 'comment',
+    nullable: true,
+    length: 4000,
+  })
+  comment: string | null;
+
+  @Column('integer', { name: 'row_version_count' })
+  rowVersionCount: number;
+
+  @Column('character varying', { name: 'created_by', length: 20 })
+  createdBy: string;
+
+  @Column('timestamp without time zone', { name: 'created_date_time' })
+  createdDateTime: Date;
+
+  @Column('character varying', { name: 'updated_by', length: 20 })
+  updatedBy: string;
+
+  @Column('timestamp without time zone', { name: 'updated_date_time' })
+  updatedDateTime: Date;
+
+  @Column('bytea', { name: 'ts' })
+  ts: Buffer;
+
+  @ManyToOne(() => Application)
+  @JoinColumn([{ name: 'application_id', referencedColumnName: 'id' }])
+  application: Application;
+
+  @ManyToOne(() => Person)
+  @JoinColumn([{ name: 'person_id', referencedColumnName: 'id' }])
+  person: Person;
+}

--- a/backend/cats/src/app/resolvers/timesheetDay.resolver.spec.ts
+++ b/backend/cats/src/app/resolvers/timesheetDay.resolver.spec.ts
@@ -1,0 +1,187 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TimesheetDayResolver } from './timesheetDay.resolver';
+import { TimesheetDayService } from '../services/timesheetDay.service';
+import { GenericResponseProvider } from '../dto/response/genericResponseProvider';
+import { LoggerService } from '../logger/logger.service';
+import { HttpStatus } from '@nestjs/common';
+import {
+  UpsertTimesheetDaysInputDto,
+  TimesheetDayDto,
+  PersonWithTimesheetDaysDto,
+} from '../dto/timesheetDay.dto';
+
+describe('TimesheetDayResolver', () => {
+  let resolver: TimesheetDayResolver;
+  let service: TimesheetDayService;
+  let responseProvider: GenericResponseProvider<any>;
+  let logger: LoggerService;
+
+  const mockUser = { name: 'Test User' };
+  const mockTimesheetData: TimesheetDayDto[] = [
+    {
+      id: 1,
+      applicationId: 1,
+      personId: 2,
+      date: new Date('2025-06-01'),
+      hours: 8,
+    },
+  ];
+
+  const mockPersonWithTimesheetData: PersonWithTimesheetDaysDto[] = [
+    {
+      personId: 2,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'jdoe@example.com',
+      timesheetDays: [
+        {
+          id: 1,
+          applicationId: 1,
+          personId: 2,
+          date: new Date('2025-06-01'),
+          hours: 8,
+        },
+      ],
+    },
+  ];
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TimesheetDayResolver,
+        {
+          provide: TimesheetDayService,
+          useValue: {
+            upsertTimesheetDays: jest.fn(),
+            getTimesheetDaysForAssignedStaff: jest.fn(),
+          },
+        },
+        {
+          provide: GenericResponseProvider,
+          useValue: {
+            createResponse: jest.fn(),
+          },
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<TimesheetDayResolver>(TimesheetDayResolver);
+    service = module.get<TimesheetDayService>(TimesheetDayService);
+    responseProvider = module.get<GenericResponseProvider<any>>(
+      GenericResponseProvider,
+    );
+    logger = module.get<LoggerService>(LoggerService);
+  });
+
+  describe('upsertTimesheetDays', () => {
+    it('should call service and return success response', async () => {
+      const input: UpsertTimesheetDaysInputDto = {
+        entries: [
+          { applicationId: 1, personId: 2, date: '2025-06-01', hours: 8 },
+        ],
+      };
+      jest
+        .spyOn(service, 'upsertTimesheetDays')
+        .mockResolvedValue(mockTimesheetData as any);
+
+      const result = await resolver.upsertTimesheetDays(input, mockUser);
+      expect(service.upsertTimesheetDays).toHaveBeenCalledWith(
+        input.entries,
+        mockUser,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          message: 'Timesheet days upserted successfully',
+          httpStatusCode: HttpStatus.CREATED,
+          success: true,
+          data: mockTimesheetData,
+        }),
+      );
+    });
+
+    it('should return error response on failure', async () => {
+      const input: UpsertTimesheetDaysInputDto = {
+        entries: [
+          { applicationId: 1, personId: 2, date: '2025-06-01', hours: 8 },
+        ],
+      };
+      jest
+        .spyOn(service, 'upsertTimesheetDays')
+        .mockRejectedValue(new Error('Test error'));
+
+      const result = await resolver.upsertTimesheetDays(input, mockUser);
+      expect(service.upsertTimesheetDays).toHaveBeenCalledWith(
+        input.entries,
+        mockUser,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          message: 'Test error',
+          httpStatusCode: HttpStatus.BAD_REQUEST,
+          success: false,
+          data: [],
+        }),
+      );
+    });
+  });
+
+  describe('getTimesheetDaysForAssignedStaff', () => {
+    it('should call service and return success response', async () => {
+      jest
+        .spyOn(service, 'getTimesheetDaysForAssignedStaff')
+        .mockResolvedValue(mockPersonWithTimesheetData as any);
+      const result = await resolver.getTimesheetDaysForAssignedStaff(
+        1,
+        '2025-06-01',
+        '2025-06-30',
+        mockUser,
+      );
+      expect(service.getTimesheetDaysForAssignedStaff).toHaveBeenCalledWith(
+        1,
+        '2025-06-01',
+        '2025-06-30',
+        mockUser,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          message: 'Fetched timesheet days for assigned staff',
+          httpStatusCode: HttpStatus.OK,
+          success: true,
+          data: mockPersonWithTimesheetData,
+        }),
+      );
+    });
+    it('should return error response on failure', async () => {
+      jest
+        .spyOn(service, 'getTimesheetDaysForAssignedStaff')
+        .mockRejectedValue(new Error('Test error'));
+      const result = await resolver.getTimesheetDaysForAssignedStaff(
+        1,
+        '2025-06-01',
+        '2025-06-30',
+        mockUser,
+      );
+      expect(service.getTimesheetDaysForAssignedStaff).toHaveBeenCalledWith(
+        1,
+        '2025-06-01',
+        '2025-06-30',
+        mockUser,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          message: 'Test error',
+          httpStatusCode: HttpStatus.BAD_REQUEST,
+          success: false,
+          data: [],
+        }),
+      );
+    });
+  });
+});

--- a/backend/cats/src/app/resolvers/timesheetDay.resolver.ts
+++ b/backend/cats/src/app/resolvers/timesheetDay.resolver.ts
@@ -1,0 +1,113 @@
+import { Args, Mutation, Resolver, Query } from '@nestjs/graphql';
+import { HttpStatus, UsePipes } from '@nestjs/common';
+import { TimesheetDayService } from '../services/timesheetDay.service';
+import {
+  TimesheetDayDto,
+  TimesheetDayResponse,
+  UpsertTimesheetDaysInputDto,
+  PersonWithTimesheetDaysDto,
+  PersonWithTimesheetDaysResponse,
+} from '../dto/timesheetDay.dto';
+import { GenericResponseProvider } from '../dto/response/genericResponseProvider';
+import { GenericValidationPipe } from '../utils/validations/genericValidationPipe';
+import { AuthenticatedUser } from 'nest-keycloak-connect';
+import { LoggerService } from '../logger/logger.service';
+
+@Resolver(() => TimesheetDayDto)
+export class TimesheetDayResolver {
+  constructor(
+    private readonly timesheetDayService: TimesheetDayService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  @Mutation(() => TimesheetDayResponse, { name: 'upsertTimesheetDays' })
+  @UsePipes(new GenericValidationPipe())
+  async upsertTimesheetDays(
+    @Args('input') input: UpsertTimesheetDaysInputDto,
+    @AuthenticatedUser() user: any,
+  ) {
+    const responseProvider = new GenericResponseProvider<TimesheetDayDto[]>();
+    this.loggerService.log(
+      `Received upsertTimesheetDays mutation by user: ${user?.name}`,
+    );
+    try {
+      const result = await this.timesheetDayService.upsertTimesheetDays(
+        input.entries,
+        user,
+      );
+      const dtos: TimesheetDayDto[] = result.map((item) => ({
+        id: item.id,
+        applicationId: item.applicationId,
+        personId: item.personId,
+        date: new Date(item.date),
+        hours: item.hours ? parseFloat(item.hours) : 0,
+      }));
+      this.loggerService.log(
+        `Successfully upserted ${dtos.length} timesheet day entries by user: ${user?.name}`,
+      );
+      return responseProvider.createResponse(
+        'Timesheet days upserted successfully',
+        HttpStatus.CREATED,
+        true,
+        dtos,
+      );
+    } catch (error) {
+      this.loggerService.error(
+        `Error in upsertTimesheetDays resolver: ${error.message}`,
+        error.stack,
+      );
+      return responseProvider.createResponse(
+        error.message || 'Failed to upsert timesheet days',
+        HttpStatus.BAD_REQUEST,
+        false,
+        [],
+      );
+    }
+  }
+
+  @Query(() => PersonWithTimesheetDaysResponse, {
+    name: 'getTimesheetDaysForAssignedStaff',
+  })
+  async getTimesheetDaysForAssignedStaff(
+    @Args('applicationId', { type: () => Number }) applicationId: number,
+    @Args('startDate', { type: () => String }) startDate: string,
+    @Args('endDate', { type: () => String }) endDate: string,
+    @AuthenticatedUser() user: any,
+  ): Promise<PersonWithTimesheetDaysResponse> {
+    const responseProvider = new GenericResponseProvider<
+      PersonWithTimesheetDaysDto[]
+    >();
+    this.loggerService.log(
+      `Received getTimesheetDaysForAssignedStaff query for applicationId=${applicationId}, startDate=${startDate}, endDate=${endDate}, user: ${user?.name}`,
+    );
+    try {
+      const data =
+        await this.timesheetDayService.getTimesheetDaysForAssignedStaff(
+          applicationId,
+          startDate,
+          endDate,
+          user,
+        );
+      this.loggerService.log(
+        `Successfully fetched timesheet days for assigned staff for applicationId=${applicationId}`,
+      );
+      return responseProvider.createResponse(
+        'Fetched timesheet days for assigned staff',
+        HttpStatus.OK,
+        true,
+        data,
+      );
+    } catch (error) {
+      this.loggerService.error(
+        `Error in getTimesheetDaysForAssignedStaff resolver: ${error.message}`,
+        error.stack,
+      );
+      return responseProvider.createResponse(
+        error.message || 'Failed to fetch timesheet days for assigned staff',
+        HttpStatus.BAD_REQUEST,
+        false,
+        [],
+      );
+    }
+  }
+}

--- a/backend/cats/src/app/services/timesheetDay.service.spec.ts
+++ b/backend/cats/src/app/services/timesheetDay.service.spec.ts
@@ -1,0 +1,271 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TimesheetDayService } from './timesheetDay.service';
+import { TimesheetDay } from '../entities/timesheetDay.entity';
+import { Application } from '../entities/application.entity';
+import { Person } from '../entities/person.entity';
+import { LoggerService } from '../logger/logger.service';
+import { TimesheetDayUpsertInputDto } from '../dto/timesheetDay.dto';
+import { HttpException } from '@nestjs/common';
+import { StaffAssignmentService } from './assignment/staffAssignment.service';
+
+describe('TimesheetDayService', () => {
+  let service: TimesheetDayService;
+  let timesheetDayRepository: Repository<TimesheetDay>;
+  let applicationRepository: Repository<Application>;
+  let personRepository: Repository<Person>;
+  let logger: LoggerService;
+  let staffAssignmentService: StaffAssignmentService;
+
+  const mockUser = { name: 'Test User' };
+  const mockApplication = { id: 1 } as Application;
+  const mockPerson = { id: 2 } as Person;
+  const mockTimesheetDay = {
+    id: 10,
+    applicationId: 1,
+    personId: 2,
+    date: '2025-06-01',
+    hours: '8',
+    rowVersionCount: 0,
+    createdBy: 'Test User',
+    createdDateTime: new Date(),
+    updatedBy: 'Test User',
+    updatedDateTime: new Date(),
+    ts: Buffer.from(''),
+  } as TimesheetDay;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TimesheetDayService,
+        { provide: getRepositoryToken(TimesheetDay), useClass: Repository },
+        { provide: getRepositoryToken(Application), useClass: Repository },
+        { provide: getRepositoryToken(Person), useClass: Repository },
+        {
+          provide: LoggerService,
+          useValue: { log: jest.fn(), error: jest.fn() },
+        },
+        {
+          provide: StaffAssignmentService,
+          useValue: { getStaffByAppId: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TimesheetDayService>(TimesheetDayService);
+    timesheetDayRepository = module.get<Repository<TimesheetDay>>(
+      getRepositoryToken(TimesheetDay),
+    );
+    applicationRepository = module.get<Repository<Application>>(
+      getRepositoryToken(Application),
+    );
+    personRepository = module.get<Repository<Person>>(
+      getRepositoryToken(Person),
+    );
+    logger = module.get<LoggerService>(LoggerService);
+    staffAssignmentService = module.get<StaffAssignmentService>(
+      StaffAssignmentService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('upsertTimesheetDays', () => {
+    it('should create new timesheet day entries', async () => {
+      const input: TimesheetDayUpsertInputDto[] = [
+        { applicationId: 1, personId: 2, date: '2025-06-01', hours: 8 },
+      ];
+      jest
+        .spyOn(applicationRepository, 'findOne')
+        .mockResolvedValue(mockApplication);
+      jest.spyOn(personRepository, 'findOne').mockResolvedValue(mockPerson);
+      jest
+        .spyOn(timesheetDayRepository, 'create')
+        .mockReturnValue(mockTimesheetDay);
+      jest
+        .spyOn(timesheetDayRepository, 'save')
+        .mockResolvedValue(mockTimesheetDay);
+
+      const result = await service.upsertTimesheetDays(input, mockUser);
+      expect(result).toHaveLength(1);
+      expect(timesheetDayRepository.create).toHaveBeenCalled();
+      expect(timesheetDayRepository.save).toHaveBeenCalled();
+    });
+
+    it('should update existing timesheet day entries', async () => {
+      const input: TimesheetDayUpsertInputDto[] = [
+        {
+          timesheetDayId: 10,
+          applicationId: 1,
+          personId: 2,
+          date: '2025-06-01',
+          hours: 8,
+        },
+      ];
+      jest
+        .spyOn(applicationRepository, 'findOne')
+        .mockResolvedValue(mockApplication);
+      jest.spyOn(personRepository, 'findOne').mockResolvedValue(mockPerson);
+      jest
+        .spyOn(timesheetDayRepository, 'findOne')
+        .mockResolvedValue(mockTimesheetDay);
+      jest
+        .spyOn(timesheetDayRepository, 'save')
+        .mockResolvedValue(mockTimesheetDay);
+
+      const result = await service.upsertTimesheetDays(input, mockUser);
+      expect(result).toHaveLength(1);
+      expect(timesheetDayRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw if application not found', async () => {
+      const input: TimesheetDayUpsertInputDto[] = [
+        { applicationId: 999, personId: 2, date: '2025-06-01', hours: 8 },
+      ];
+      jest.spyOn(applicationRepository, 'findOne').mockResolvedValue(undefined);
+      await expect(
+        service.upsertTimesheetDays(input, mockUser),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should throw if person not found', async () => {
+      const input: TimesheetDayUpsertInputDto[] = [
+        { applicationId: 1, personId: 999, date: '2025-06-01', hours: 8 },
+      ];
+      jest
+        .spyOn(applicationRepository, 'findOne')
+        .mockResolvedValue(mockApplication);
+      jest.spyOn(personRepository, 'findOne').mockResolvedValue(undefined);
+      await expect(
+        service.upsertTimesheetDays(input, mockUser),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should throw if updating non-existent timesheet day', async () => {
+      const input: TimesheetDayUpsertInputDto[] = [
+        {
+          timesheetDayId: 999,
+          applicationId: 1,
+          personId: 2,
+          date: '2025-06-01',
+          hours: 8,
+        },
+      ];
+      jest
+        .spyOn(applicationRepository, 'findOne')
+        .mockResolvedValue(mockApplication);
+      jest.spyOn(personRepository, 'findOne').mockResolvedValue(mockPerson);
+      jest
+        .spyOn(timesheetDayRepository, 'findOne')
+        .mockResolvedValue(undefined);
+      await expect(
+        service.upsertTimesheetDays(input, mockUser),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should throw validation errors if input is missing required fields', async () => {
+      const input: TimesheetDayUpsertInputDto[] = [{} as any];
+      await expect(
+        service.upsertTimesheetDays(input, mockUser),
+      ).rejects.toThrow(HttpException);
+      try {
+        await service.upsertTimesheetDays(input, mockUser);
+      } catch (e) {
+        const errors = e.getResponse().errors;
+        expect(errors).toContain('Application ID is required');
+        expect(errors).toContain('Person ID is required');
+        expect(errors).toContain('Date is required');
+      }
+    });
+  });
+
+  describe('getTimesheetDaysForAssignedStaff', () => {
+    it('should return timesheet days for assigned staff', async () => {
+      const mockStaffList = [
+        {
+          id: 1,
+          applicationId: 1,
+          personId: 2,
+          roleId: 1,
+          startDate: new Date(),
+          endDate: new Date(),
+          currentCapacity: 0,
+        },
+      ];
+      const mockStaffResult = {
+        applicationServiceTypeId: null,
+        staffList: mockStaffList,
+      };
+      const mockPerson = {
+        id: 2,
+        firstName: 'John',
+        lastName: 'Doe',
+        middleName: null,
+        loginUserName: 'jdoe',
+        email: 'jdoe@example.com',
+      };
+      const mockTimesheetDay = {
+        id: 1,
+        applicationId: 1,
+        personId: 2,
+        date: '2025-06-01',
+        hours: '8',
+      };
+      jest
+        .spyOn(staffAssignmentService, 'getStaffByAppId')
+        .mockResolvedValue(mockStaffResult);
+      jest
+        .spyOn(personRepository, 'findByIds')
+        .mockResolvedValue([mockPerson] as any);
+      jest
+        .spyOn(timesheetDayRepository, 'find')
+        .mockResolvedValue([mockTimesheetDay] as any);
+      const result = await service.getTimesheetDaysForAssignedStaff(
+        1,
+        '2025-06-01',
+        '2025-06-30',
+        mockUser,
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].personId).toBe(2);
+      expect(result[0].timesheetDays).toHaveLength(1);
+      expect(staffAssignmentService.getStaffByAppId).toHaveBeenCalled();
+      expect(personRepository.findByIds).toHaveBeenCalled();
+      expect(timesheetDayRepository.find).toHaveBeenCalled();
+    });
+    it('should return empty array if no staff assigned', async () => {
+      const mockStaffList = [{ personId: 2 }];
+      const mockStaffResult = {
+        applicationServiceTypeId: null,
+        staffList: mockStaffList,
+      };
+      jest
+        .spyOn(staffAssignmentService, 'getStaffByAppId')
+        .mockResolvedValue({ applicationServiceTypeId: null, staffList: [] });
+      const result = await service.getTimesheetDaysForAssignedStaff(
+        1,
+        '2025-06-01',
+        '2025-06-30',
+        mockUser,
+      );
+      expect(result).toEqual([]);
+    });
+    it('should throw and log error on failure', async () => {
+      jest
+        .spyOn(staffAssignmentService, 'getStaffByAppId')
+        .mockRejectedValue(new Error('Test error'));
+      await expect(
+        service.getTimesheetDaysForAssignedStaff(
+          1,
+          '2025-06-01',
+          '2025-06-30',
+          mockUser,
+        ),
+      ).rejects.toThrow('Test error');
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/cats/src/app/services/timesheetDay.service.ts
+++ b/backend/cats/src/app/services/timesheetDay.service.ts
@@ -1,0 +1,197 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TimesheetDay } from '../entities/timesheetDay.entity';
+import { Application } from '../entities/application.entity';
+import { Person } from '../entities/person.entity';
+import {
+  TimesheetDayUpsertInputDto,
+  PersonWithTimesheetDaysDto,
+} from '../dto/timesheetDay.dto';
+import { LoggerService } from '../logger/logger.service';
+import { format, parseISO } from 'date-fns';
+import { In, Between } from 'typeorm';
+import { StaffAssignmentService } from './assignment/staffAssignment.service';
+
+@Injectable()
+export class TimesheetDayService {
+  constructor(
+    @InjectRepository(TimesheetDay)
+    private readonly timesheetDayRepository: Repository<TimesheetDay>,
+    @InjectRepository(Application)
+    private readonly applicationRepository: Repository<Application>,
+    @InjectRepository(Person)
+    private readonly personRepository: Repository<Person>,
+    private readonly loggerService: LoggerService,
+    private readonly staffAssignmentService: StaffAssignmentService,
+  ) {}
+
+  async upsertTimesheetDays(entries: TimesheetDayUpsertInputDto[], user: any) {
+    this.loggerService.log(
+      `Upserting ${entries.length} timesheet day entries by user: ${user?.name}`,
+    );
+    const currentUser = user?.name || 'N/A';
+    const currentDateTime = new Date();
+    const results: TimesheetDay[] = [];
+    try {
+      for (const entry of entries) {
+        const { timesheetDayId, applicationId, personId, date, hours } = entry;
+        const errors = [];
+        if (!applicationId) errors.push('Application ID is required');
+        if (!personId) errors.push('Person ID is required');
+        if (!date) errors.push('Date is required');
+        if (errors.length > 0) {
+          this.loggerService.error(
+            `Validation failed for entry: ${JSON.stringify(
+              entry,
+            )} - Errors: ${errors.join(', ')}`,
+            JSON.stringify(entry),
+          );
+          throw new HttpException(
+            { message: 'Validation failed', errors },
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+        const application = await this.applicationRepository.findOne({
+          where: { id: applicationId },
+        });
+        if (!application) {
+          this.loggerService.error(
+            `Application with ID ${applicationId} not found.`,
+            String(applicationId),
+          );
+          throw new HttpException(
+            `Application with ID ${applicationId} not found`,
+            HttpStatus.NOT_FOUND,
+          );
+        }
+        const person = await this.personRepository.findOne({
+          where: { id: personId },
+        });
+        if (!person) {
+          this.loggerService.error(
+            `Person with ID ${personId} not found.`,
+            String(personId),
+          );
+          throw new HttpException(
+            `Person with ID ${personId} not found`,
+            HttpStatus.NOT_FOUND,
+          );
+        }
+        let timesheetDay: TimesheetDay;
+        if (timesheetDayId) {
+          // Update existing
+          timesheetDay = await this.timesheetDayRepository.findOne({
+            where: { id: timesheetDayId },
+          });
+          if (!timesheetDay) {
+            this.loggerService.error(
+              `TimesheetDay with ID ${timesheetDayId} not found.`,
+              String(timesheetDayId),
+            );
+            throw new HttpException(
+              `TimesheetDay with ID ${timesheetDayId} not found`,
+              HttpStatus.NOT_FOUND,
+            );
+          }
+          timesheetDay.applicationId = applicationId;
+          timesheetDay.personId = personId;
+          timesheetDay.date = format(parseISO(date), 'yyyy-MM-dd');
+          timesheetDay.hours = hours?.toString() ?? null;
+          timesheetDay.updatedBy = currentUser;
+          timesheetDay.updatedDateTime = currentDateTime;
+          timesheetDay.rowVersionCount += 1;
+          this.loggerService.log(`Updated TimesheetDay ID ${timesheetDayId}`);
+        } else {
+          // Create new
+          timesheetDay = this.timesheetDayRepository.create({
+            applicationId,
+            personId,
+            date: format(parseISO(date), 'yyyy-MM-dd'),
+            hours: hours?.toString() ?? null,
+            rowVersionCount: 0,
+            createdBy: currentUser,
+            createdDateTime: currentDateTime,
+            updatedBy: currentUser,
+            updatedDateTime: currentDateTime,
+            ts: Buffer.from(''),
+          });
+          this.loggerService.log(
+            `Creating new TimesheetDay for applicationId=${applicationId}, personId=${personId}, date=${date}`,
+          );
+        }
+        const saved = await this.timesheetDayRepository.save(timesheetDay);
+        results.push(saved);
+      }
+      this.loggerService.log(
+        `Successfully upserted ${results.length} timesheet day entries.`,
+      );
+      return results;
+    } catch (error) {
+      this.loggerService.error(
+        `Error upserting timesheet day entries: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+
+  async getTimesheetDaysForAssignedStaff(
+    applicationId: number,
+    startDate: string,
+    endDate: string,
+    user: any,
+  ): Promise<PersonWithTimesheetDaysDto[]> {
+    this.loggerService.log(
+      `Fetching timesheet days for applicationId=${applicationId}, startDate=${startDate}, endDate=${endDate}`,
+    );
+    try {
+      const staffResult = await this.staffAssignmentService.getStaffByAppId(
+        applicationId,
+        user,
+      );
+      const staffList = staffResult.staffList || [];
+      if (!staffList.length) {
+        this.loggerService.log(
+          `No staff assigned to applicationId=${applicationId}`,
+        );
+        return [];
+      }
+      const personIds = staffList.map((s) => s.personId);
+      const people = await this.personRepository.findByIds(personIds);
+      const timesheetDays = await this.timesheetDayRepository.find({
+        where: {
+          applicationId,
+          personId: In(personIds),
+          date: Between(startDate, endDate),
+        },
+      });
+      this.loggerService.log(
+        `Fetched timesheet days for ${people.length} staff.`,
+      );
+      return people.map((person) => ({
+        personId: person.id,
+        firstName: person.firstName,
+        middleName: person.middleName,
+        lastName: person.lastName,
+        loginUserName: person.loginUserName,
+        email: person.email,
+        timesheetDays: timesheetDays
+          .filter((t) => t.personId === person.id)
+          .map((t) => ({
+            id: t.id,
+            applicationId: t.applicationId,
+            personId: t.personId,
+            date: new Date(t.date),
+            hours: t.hours ? parseFloat(t.hours) : undefined,
+          })),
+      }));
+    } catch (error) {
+      this.loggerService.error(
+        `Error fetching timesheet days for assigned staff: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+}

--- a/backend/cats/src/migrations/1746549000000-create-timesheet-day.ts
+++ b/backend/cats/src/migrations/1746549000000-create-timesheet-day.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createTimesheetDay1746549000000 implements MigrationInterface {
+  name = 'createTimesheetDay1746549000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "cats"."timesheet_day" (
+        "id" SERIAL NOT NULL,
+        "application_id" integer NOT NULL,
+        "person_id" integer NOT NULL,
+        "date" date NOT NULL,
+        "description" character varying(255),
+        "hours" numeric(5,2),
+        "comment" character varying(4000),
+        "row_version_count" integer NOT NULL,
+        "created_by" character varying(20) NOT NULL,
+        "created_date_time" TIMESTAMP NOT NULL,
+        "updated_by" character varying(20) NOT NULL,
+        "updated_date_time" TIMESTAMP NOT NULL,
+        "ts" bytea NOT NULL,
+        CONSTRAINT "PK_timesheet_day" PRIMARY KEY ("id")
+      )`);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "pk_timesheet_day" ON "cats"."timesheet_day" ("id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_timesheet_day_application_id" ON "cats"."timesheet_day" ("application_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_timesheet_day_person_id" ON "cats"."timesheet_day" ("person_id")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cats"."timesheet_day" ADD CONSTRAINT "FK_timesheet_day_application_id" FOREIGN KEY ("application_id") REFERENCES "cats"."application"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cats"."timesheet_day" ADD CONSTRAINT "FK_timesheet_day_person_id" FOREIGN KEY ("person_id") REFERENCES "cats"."person"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "cats"."timesheet_day" DROP CONSTRAINT "FK_timesheet_day_person_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cats"."timesheet_day" DROP CONSTRAINT "FK_timesheet_day_application_id"`,
+    );
+    await queryRunner.query(`DROP INDEX "cats"."idx_timesheet_day_person_id"`);
+    await queryRunner.query(
+      `DROP INDEX "cats"."idx_timesheet_day_application_id"`,
+    );
+    await queryRunner.query(`DROP INDEX "cats"."pk_timesheet_day"`);
+    await queryRunner.query(`DROP TABLE "cats"."timesheet_day"`);
+  }
+}

--- a/cats-frontend/src/generated/types.ts
+++ b/cats-frontend/src/generated/types.ts
@@ -254,6 +254,7 @@ export type InvoiceByApplicationIdDto = {
   id: Scalars['Int']['output'];
   issuedDate: Scalars['DateTime']['output'];
   status: Scalars['String']['output'];
+  subject: Scalars['String']['output'];
   totalInCents: Scalars['Int']['output'];
 };
 
@@ -265,7 +266,7 @@ export type InvoiceDto = {
   dueDate: Scalars['DateTime']['output'];
   gstInCents: Scalars['Int']['output'];
   id: Scalars['Int']['output'];
-  invoiceId: Scalars['Int']['output'];
+  invoiceId?: Maybe<Scalars['Int']['output']>;
   issuedDate: Scalars['DateTime']['output'];
   lineItems: Array<InvoiceLineItemDto>;
   pstInCents: Scalars['Int']['output'];
@@ -283,9 +284,9 @@ export type InvoiceInputDto = {
   applicationId: Scalars['Int']['input'];
   dueDate: Scalars['DateTime']['input'];
   gstInCents: Scalars['Int']['input'];
-  invoiceId: Scalars['Int']['input'];
+  invoiceId?: InputMaybe<Scalars['Int']['input']>;
   issuedDate: Scalars['DateTime']['input'];
-  lineItems: Array<InvoiceLineItemCreateDto>;
+  lineItems: Array<InvoiceLineItemInputDto>;
   pstInCents: Scalars['Int']['input'];
   recipientId: Scalars['Int']['input'];
   status: InvoiceStatus;
@@ -293,14 +294,6 @@ export type InvoiceInputDto = {
   subtotalInCents: Scalars['Int']['input'];
   taxExempt: Scalars['Boolean']['input'];
   totalInCents: Scalars['Int']['input'];
-};
-
-export type InvoiceLineItemCreateDto = {
-  description: Scalars['String']['input'];
-  quantity: Scalars['Int']['input'];
-  totalInCents: Scalars['Int']['input'];
-  type: Scalars['String']['input'];
-  unitPriceInCents: Scalars['Int']['input'];
 };
 
 export type InvoiceLineItemDto = {
@@ -317,10 +310,21 @@ export type InvoiceLineItemDto = {
   updatedBy: Scalars['String']['output'];
 };
 
+export type InvoiceLineItemInputDto = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  createdBy?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['Float']['input']>;
+  quantity: Scalars['Int']['input'];
+  totalInCents: Scalars['Int']['input'];
+  type: Scalars['String']['input'];
+  unitPriceInCents: Scalars['Int']['input'];
+};
+
 export type InvoiceResponse = {
   __typename?: 'InvoiceResponse';
   httpStatusCode?: Maybe<Scalars['Int']['output']>;
-  invoice?: Maybe<Array<InvoiceDto>>;
+  invoice?: Maybe<InvoiceDto>;
   message?: Maybe<Scalars['String']['output']>;
   success?: Maybe<Scalars['Boolean']['output']>;
   timestamp?: Maybe<Scalars['String']['output']>;
@@ -359,6 +363,7 @@ export type Mutation = {
   updatePerson: PersonResponse;
   updatePersonNote: PersonNoteResponse;
   updateStaffAssigned: ResponseDto;
+  upsertTimesheetDays: TimesheetDayResponse;
 };
 
 
@@ -433,6 +438,11 @@ export type MutationUpdateStaffAssignedArgs = {
   applicationId: Scalars['Int']['input'];
   applicationServiceTypeId: Scalars['Int']['input'];
   staffInput: Array<UpdateStaffAssignedDto>;
+};
+
+
+export type MutationUpsertTimesheetDaysArgs = {
+  input: UpsertTimesheetDaysInputDto;
 };
 
 export type ParticipantsRolesResponse = {
@@ -639,6 +649,32 @@ export enum StaffSortByField {
   Name = 'NAME'
 }
 
+export type TimesheetDayDto = {
+  __typename?: 'TimesheetDayDto';
+  applicationId: Scalars['Int']['output'];
+  date: Scalars['DateTime']['output'];
+  hours?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['Int']['output'];
+  personId: Scalars['Int']['output'];
+};
+
+export type TimesheetDayResponse = {
+  __typename?: 'TimesheetDayResponse';
+  data: Array<TimesheetDayDto>;
+  httpStatusCode?: Maybe<Scalars['Int']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
+  timestamp?: Maybe<Scalars['String']['output']>;
+};
+
+export type TimesheetDayUpsertInputDto = {
+  applicationId: Scalars['Int']['input'];
+  date: Scalars['String']['input'];
+  hours?: InputMaybe<Scalars['Float']['input']>;
+  personId: Scalars['Int']['input'];
+  timesheetDayId?: InputMaybe<Scalars['Int']['input']>;
+};
+
 export type UpdateAppParticipantDto = {
   applicationId: Scalars['Float']['input'];
   effectiveEndDate?: InputMaybe<Scalars['DateTime']['input']>;
@@ -704,6 +740,10 @@ export type UpdateStaffAssignedDto = {
   personId: Scalars['Float']['input'];
   roleId: Scalars['Float']['input'];
   startDate: Scalars['DateTime']['input'];
+};
+
+export type UpsertTimesheetDaysInputDto = {
+  entries: Array<TimesheetDayUpsertInputDto>;
 };
 
 export type ViewAppParticipantEntityDto = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

In this PR:
- New TimeSheetDay entity and database migration
- Graphql mutation for creating and updating timesheet days (combined into one "upsert" operation capable of processing batch upserts
- Graphql query for fetching timesheet days for application within time range, grouped by assigned staff

Fixes [SRS-785](https://env-epd.atlassian.net/browse/SRS-785)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

Examples:

```graphql
mutation {
  upsertTimesheetDays(input: {
    entries: [
      { applicationId: 1, personId: 629, date: "2025-06-01", hours: 8 },
      { applicationId: 1, personId: 629, date: "2025-06-02", hours: 7.5, timesheetDayId: 2 }
    ]
  }) {
    data {
      id
      applicationId
      personId
      date
      hours
    }
    message
    success
  }
}
```

Response:
```json
{
    "data": {
        "upsertTimesheetDays": {
            "data": [
                {
                    "id": 11,
                    "applicationId": 1,
                    "personId": 629,
                    "date": "2025-06-01T00:00:00.000Z",
                    "hours": 8
                },
                {
                    "id": 2,
                    "applicationId": 1,
                    "personId": 629,
                    "date": "2025-06-02T00:00:00.000Z",
                    "hours": 7.5
                }
            ],
            "message": "Timesheet days upserted successfully",
            "success": true
        }
    }
}
```

```graphql
{
    getTimesheetDaysForAssignedStaff(
        applicationId: 1
        startDate: "2025-06-01"
        endDate: "2025-06-07"
    ) {
        data {
            personId
            timesheetDays {
                id
                date
            }
        }
    }
}
```

Response:
```json
{
    "data": {
        "getTimesheetDaysForAssignedStaff": {
            "data": [
                {
                    "personId": 629,
                    "timesheetDays": [
                        {
                            "id": 10,
                            "date": "2025-06-01T00:00:00.000Z"
                        },
                        {
                            "id": 2,
                            "date": "2025-06-02T00:00:00.000Z"
                        }
                    ]
                }
            ]
        }
    }
}
```


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-908-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-908-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)