### PR TITLE
fix: SRS -948 : Fix date issue

### DIFF
--- a/cats-frontend/src/app/components/input-controls/InputControls.tsx
+++ b/cats-frontend/src/app/components/input-controls/InputControls.tsx
@@ -6,7 +6,12 @@ import React, {
   useState,
 } from 'react';
 import { FormFieldType, IFormField } from './IFormField';
-import { formatDate, formatDateRange, normalizeDate, parseLocalDate } from '../../helpers/utility';
+import {
+  formatDate,
+  formatDateRange,
+  normalizeDate,
+  parseLocalDate,
+} from '../../helpers/utility';
 import { DatePicker, DateRangePicker } from 'rsuite';
 import {
   CalendarIcon,
@@ -757,21 +762,20 @@ export const DateInput: React.FC<InputProps> = ({
   let dateValue;
 
   if (value != null && value !== '') {
-    value =
-      tableMode
-        ? value instanceof Date
-          ? normalizeDate(value)
-          : parseLocalDate(value)
-        : (!tableMode && isEditing && value instanceof Date)
-          ? normalizeDate(value)
-          : parseLocalDate(value);
+    value = tableMode
+      ? value instanceof Date
+        ? normalizeDate(value)
+        : parseLocalDate(value)
+      : !tableMode && isEditing && value instanceof Date
+        ? normalizeDate(value)
+        : parseLocalDate(value);
   }
-  
+
   // Format for UI
   if (value) {
     dateValue = formatDate(value, dateFormat ?? 'MMM dd, yyyy');
-  } 
-  
+  }
+
   const handleCheckBoxChange = (isChecked: boolean) => {
     onChange(isChecked);
   };

--- a/cats-frontend/src/app/components/input-controls/InputControls.tsx
+++ b/cats-frontend/src/app/components/input-controls/InputControls.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { FormFieldType, IFormField } from './IFormField';
-import { formatDate, formatDateRange, formatDateUTC, normalizeDate, parseLocalDate } from '../../helpers/utility';
+import { formatDate, formatDateRange, normalizeDate, parseLocalDate } from '../../helpers/utility';
 import { DatePicker, DateRangePicker } from 'rsuite';
 import {
   CalendarIcon,
@@ -28,7 +28,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './InputControls.module.css';
-import { format } from 'date-fns';
 
 interface InputProps extends IFormField {
   children?: InputProps[];
@@ -765,7 +764,7 @@ export const DateInput: React.FC<InputProps> = ({
           : parseLocalDate(value)
         : (!tableMode && isEditing && value instanceof Date)
           ? normalizeDate(value)
-          : value;
+          : parseLocalDate(value);
   }
   
   // Format for UI

--- a/cats-frontend/src/app/components/input-controls/InputControls.tsx
+++ b/cats-frontend/src/app/components/input-controls/InputControls.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { FormFieldType, IFormField } from './IFormField';
-import { formatDate, formatDateRange } from '../../helpers/utility';
+import { formatDate, formatDateRange, formatDateUTC, normalizeDate, parseLocalDate } from '../../helpers/utility';
 import { DatePicker, DateRangePicker } from 'rsuite';
 import {
   CalendarIcon,
@@ -28,6 +28,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './InputControls.module.css';
+import { format } from 'date-fns';
 
 interface InputProps extends IFormField {
   children?: InputProps[];
@@ -756,13 +757,22 @@ export const DateInput: React.FC<InputProps> = ({
   const ContainerElement = tableMode ? 'td' : 'div';
   let dateValue;
 
-  value = tableMode ? (value != '' ? new Date(value) : null) : value;
-  value = !tableMode && isEditing && value != null ? new Date(value) : value;
-
-  if (value) {
-    dateValue = formatDate(new Date(value), dateFormat);
+  if (value != null && value !== '') {
+    value =
+      tableMode
+        ? value instanceof Date
+          ? normalizeDate(value)
+          : parseLocalDate(value)
+        : (!tableMode && isEditing && value instanceof Date)
+          ? normalizeDate(value)
+          : value;
   }
-
+  
+  // Format for UI
+  if (value) {
+    dateValue = formatDate(value, dateFormat ?? 'MMM dd, yyyy');
+  } 
+  
   const handleCheckBoxChange = (isChecked: boolean) => {
     onChange(isChecked);
   };

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appParticipants/ParticipantsTable.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appParticipants/ParticipantsTable.tsx
@@ -31,9 +31,6 @@ import Form from '../../../../../components/form/Form';
 import './ParticipantsTable.css';
 
 import { useParams } from 'react-router-dom';
-import App from '../../../../../../App';
-import { formatDateUTC, parseLocalDate } from '@cats/helpers/utility';
-import { UTCDate } from '@date-fns/utc';
 
 export const AppParticipantsActionTypes = {
   AddParticipant: 'Add Participant',
@@ -253,8 +250,8 @@ const ParticipantTable: React.FC<IParticipantTableProps> = ({
         appParticipantDetails: {
           id: appParticipantEditDetails.id,
           isMainParticipant: appParticipantEditDetails.isMainParticipant,
-          effectiveStartDate: appParticipantEditDetails.effectiveStartDate ? parseLocalDate(appParticipantEditDetails.effectiveStartDate) : null,
-          effectiveEndDate: appParticipantEditDetails.effectiveEndDate ? parseLocalDate(appParticipantEditDetails.effectiveEndDate) : null,
+          effectiveStartDate: appParticipantEditDetails.effectiveStartDate,
+          effectiveEndDate: appParticipantEditDetails.effectiveEndDate || null,
           participantRole: appParticipantRole.id.toString(),
           person: appParticipantName.id.toString(),
           organization: appParticipantOrganization?.id?.toString() ?? '',

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appParticipants/ParticipantsTable.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appParticipants/ParticipantsTable.tsx
@@ -141,15 +141,15 @@ const ParticipantTable: React.FC<IParticipantTableProps> = ({
   });
 
   type appParticipantDetailsType = {
-    id: string,
-    isMainParticipant: boolean,
-    effectiveStartDate: Date | string | null,
-    effectiveEndDate: Date | string | null,
-    participantRole: string,
-    person: string,
-    organization: string, // Assign an empty string as the initial value
-  }
-  const initialAppParticipantDetails : appParticipantDetailsType= {
+    id: string;
+    isMainParticipant: boolean;
+    effectiveStartDate: Date | string | null;
+    effectiveEndDate: Date | string | null;
+    participantRole: string;
+    person: string;
+    organization: string; // Assign an empty string as the initial value
+  };
+  const initialAppParticipantDetails: appParticipantDetailsType = {
     id: '',
     isMainParticipant: false,
     effectiveStartDate: null,

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appParticipants/ParticipantsTable.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appParticipants/ParticipantsTable.tsx
@@ -32,6 +32,8 @@ import './ParticipantsTable.css';
 
 import { useParams } from 'react-router-dom';
 import App from '../../../../../../App';
+import { formatDateUTC, parseLocalDate } from '@cats/helpers/utility';
+import { UTCDate } from '@date-fns/utc';
 
 export const AppParticipantsActionTypes = {
   AddParticipant: 'Add Participant',
@@ -141,11 +143,20 @@ const ParticipantTable: React.FC<IParticipantTableProps> = ({
     },
   });
 
-  const initialAppParticipantDetails = {
+  type appParticipantDetailsType = {
+    id: string,
+    isMainParticipant: boolean,
+    effectiveStartDate: Date | string | null,
+    effectiveEndDate: Date | string | null,
+    participantRole: string,
+    person: string,
+    organization: string, // Assign an empty string as the initial value
+  }
+  const initialAppParticipantDetails : appParticipantDetailsType= {
     id: '',
     isMainParticipant: false,
-    effectiveStartDate: '',
-    effectiveEndDate: '',
+    effectiveStartDate: null,
+    effectiveEndDate: null,
     participantRole: '',
     person: '',
     organization: '', // Assign an empty string as the initial value
@@ -242,8 +253,8 @@ const ParticipantTable: React.FC<IParticipantTableProps> = ({
         appParticipantDetails: {
           id: appParticipantEditDetails.id,
           isMainParticipant: appParticipantEditDetails.isMainParticipant,
-          effectiveStartDate: appParticipantEditDetails.effectiveStartDate,
-          effectiveEndDate: appParticipantEditDetails.effectiveEndDate,
+          effectiveStartDate: appParticipantEditDetails.effectiveStartDate ? parseLocalDate(appParticipantEditDetails.effectiveStartDate) : null,
+          effectiveEndDate: appParticipantEditDetails.effectiveEndDate ? parseLocalDate(appParticipantEditDetails.effectiveEndDate) : null,
           participantRole: appParticipantRole.id.toString(),
           person: appParticipantName.id.toString(),
           organization: appParticipantOrganization?.id?.toString() ?? '',

--- a/cats-frontend/src/app/helpers/utility.ts
+++ b/cats-frontend/src/app/helpers/utility.ts
@@ -49,6 +49,17 @@ export const formatDateRange = (
   return `${formattedStartDate} - ${formattedEndDate}`;
 };
 
+//Normalize date returned in string format e.g. '2025-06-03' (string) will be normalized to 2025-06-03T00:00:00 local
+export const parseLocalDate = (dateString: string) => {
+  const [y, m, d] = dateString.split('-').map(Number);
+  return new Date(y, m - 1, d); // Local midnight
+}
+
+/* This creates a new Date object at midnight local time (00:00:00.000) for the selected day.
+ It's a way to normalize the date without any timezone shifts caused by hours/minutes. */
+export const normalizeDate = (date: Date): Date =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
 export const formatDate = (
   date: Date,
   dateFormat: string = 'MMMM do, yyyy',

--- a/cats-frontend/src/app/helpers/utility.ts
+++ b/cats-frontend/src/app/helpers/utility.ts
@@ -53,7 +53,7 @@ export const formatDateRange = (
 export const parseLocalDate = (dateString: string) => {
   const [y, m, d] = dateString.split('-').map(Number);
   return new Date(y, m - 1, d); // Local midnight
-}
+};
 
 /* This creates a new Date object at midnight local time (00:00:00.000) for the selected day.
  It's a way to normalize the date without any timezone shifts caused by hours/minutes. */


### PR DESCRIPTION
# Description

This issue was leading to inconistent dates showed on UI vs selected in datepicker
- Date on datepicker in edit mode was not in sync
- Date selected on edit mode was not in sync

Issue: eg new Date('2025-10-02') converts the selected date to UTC midnight and thus what we see in PST is 1 day before date. 
What has been done to fix the issue: 
// FIX: Ensures the value passed to DatePicker is always a valid Date object or null.
// - Handles both string dates (e.g., '2025-06-03') and Date objects consistently.
// - Converts date strings to local Date objects using parseLocalDate.
// - Normalizes all Date objects to local midnight using normalizeDate, to avoid timezone-related UI issues.
// - Applies normalization in both table display mode and edit mode for consistent rendering and formatting.
// - Prevents DatePicker from rendering blank when editing pre-filled string dates.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-925-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-925-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)