### PR TITLE
SRS-785: Application Timesheets table

### DIFF
--- a/backend/cats/src/app/resolvers/timesheetDay.resolver.ts
+++ b/backend/cats/src/app/resolvers/timesheetDay.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Resolver, Query } from '@nestjs/graphql';
+import { Args, Mutation, Resolver, Query, Int } from '@nestjs/graphql';
 import { HttpStatus, UsePipes } from '@nestjs/common';
 import { TimesheetDayService } from '../services/timesheetDay.service';
 import {
@@ -69,7 +69,7 @@ export class TimesheetDayResolver {
     name: 'getTimesheetDaysForAssignedStaff',
   })
   async getTimesheetDaysForAssignedStaff(
-    @Args('applicationId', { type: () => Number }) applicationId: number,
+    @Args('applicationId', { type: () => Int }) applicationId: number,
     @Args('startDate', { type: () => String }) startDate: string,
     @Args('endDate', { type: () => String }) endDate: string,
     @AuthenticatedUser() user: any,

--- a/cats-frontend/src/app/components/common/icon.ts
+++ b/cats-frontend/src/app/components/common/icon.ts
@@ -37,6 +37,8 @@ import {
   FaCircleExclamation,
   FaTriangleExclamation,
   FaAddressBook,
+  FaArrowLeft,
+  FaArrowRight,
 } from 'react-icons/fa6';
 
 import {
@@ -102,3 +104,5 @@ export const UserTie = FaUserTie;
 export const CircleExclamation = FaCircleExclamation;
 export const ExclamationTriangleIcon = FaTriangleExclamation;
 export const AddressBookIcon = FaAddressBook;
+export const ArrowLeft = FaArrowLeft;
+export const ArrowRight = FaArrowRight;

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.generated.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.generated.tsx
@@ -1,0 +1,118 @@
+import * as Types from '../../../../../../generated/types';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type GetTimesheetDaysForAssignedStaffQueryVariables = Types.Exact<{
+  applicationId: Types.Scalars['Int']['input'];
+  startDate: Types.Scalars['String']['input'];
+  endDate: Types.Scalars['String']['input'];
+}>;
+
+
+export type GetTimesheetDaysForAssignedStaffQuery = { __typename?: 'Query', getTimesheetDaysForAssignedStaff: { __typename?: 'PersonWithTimesheetDaysResponse', data?: Array<{ __typename?: 'PersonWithTimesheetDaysDto', personId: number, firstName: string, lastName: string, timesheetDays: Array<{ __typename?: 'TimesheetDayDto', id: number, date: any, hours?: number | null }> }> | null } };
+
+export type UpsertTimesheetDaysMutationVariables = Types.Exact<{
+  entries: Array<Types.TimesheetDayUpsertInputDto> | Types.TimesheetDayUpsertInputDto;
+}>;
+
+
+export type UpsertTimesheetDaysMutation = { __typename?: 'Mutation', upsertTimesheetDays: { __typename?: 'TimesheetDayResponse', message?: string | null, success?: boolean | null, data: Array<{ __typename?: 'TimesheetDayDto', id: number, applicationId: number, personId: number, date: any, hours?: number | null }> } };
+
+
+export const GetTimesheetDaysForAssignedStaffDocument = gql`
+    query getTimesheetDaysForAssignedStaff($applicationId: Int!, $startDate: String!, $endDate: String!) {
+  getTimesheetDaysForAssignedStaff(
+    applicationId: $applicationId
+    startDate: $startDate
+    endDate: $endDate
+  ) {
+    data {
+      personId
+      firstName
+      lastName
+      timesheetDays {
+        id
+        date
+        hours
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetTimesheetDaysForAssignedStaffQuery__
+ *
+ * To run a query within a React component, call `useGetTimesheetDaysForAssignedStaffQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTimesheetDaysForAssignedStaffQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTimesheetDaysForAssignedStaffQuery({
+ *   variables: {
+ *      applicationId: // value for 'applicationId'
+ *      startDate: // value for 'startDate'
+ *      endDate: // value for 'endDate'
+ *   },
+ * });
+ */
+export function useGetTimesheetDaysForAssignedStaffQuery(baseOptions: Apollo.QueryHookOptions<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables> & ({ variables: GetTimesheetDaysForAssignedStaffQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables>(GetTimesheetDaysForAssignedStaffDocument, options);
+      }
+export function useGetTimesheetDaysForAssignedStaffLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables>(GetTimesheetDaysForAssignedStaffDocument, options);
+        }
+export function useGetTimesheetDaysForAssignedStaffSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables>(GetTimesheetDaysForAssignedStaffDocument, options);
+        }
+export type GetTimesheetDaysForAssignedStaffQueryHookResult = ReturnType<typeof useGetTimesheetDaysForAssignedStaffQuery>;
+export type GetTimesheetDaysForAssignedStaffLazyQueryHookResult = ReturnType<typeof useGetTimesheetDaysForAssignedStaffLazyQuery>;
+export type GetTimesheetDaysForAssignedStaffSuspenseQueryHookResult = ReturnType<typeof useGetTimesheetDaysForAssignedStaffSuspenseQuery>;
+export type GetTimesheetDaysForAssignedStaffQueryResult = Apollo.QueryResult<GetTimesheetDaysForAssignedStaffQuery, GetTimesheetDaysForAssignedStaffQueryVariables>;
+export const UpsertTimesheetDaysDocument = gql`
+    mutation upsertTimesheetDays($entries: [TimesheetDayUpsertInputDto!]!) {
+  upsertTimesheetDays(input: {entries: $entries}) {
+    data {
+      id
+      applicationId
+      personId
+      date
+      hours
+    }
+    message
+    success
+  }
+}
+    `;
+export type UpsertTimesheetDaysMutationFn = Apollo.MutationFunction<UpsertTimesheetDaysMutation, UpsertTimesheetDaysMutationVariables>;
+
+/**
+ * __useUpsertTimesheetDaysMutation__
+ *
+ * To run a mutation, you first call `useUpsertTimesheetDaysMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpsertTimesheetDaysMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [upsertTimesheetDaysMutation, { data, loading, error }] = useUpsertTimesheetDaysMutation({
+ *   variables: {
+ *      entries: // value for 'entries'
+ *   },
+ * });
+ */
+export function useUpsertTimesheetDaysMutation(baseOptions?: Apollo.MutationHookOptions<UpsertTimesheetDaysMutation, UpsertTimesheetDaysMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpsertTimesheetDaysMutation, UpsertTimesheetDaysMutationVariables>(UpsertTimesheetDaysDocument, options);
+      }
+export type UpsertTimesheetDaysMutationHookResult = ReturnType<typeof useUpsertTimesheetDaysMutation>;
+export type UpsertTimesheetDaysMutationResult = Apollo.MutationResult<UpsertTimesheetDaysMutation>;
+export type UpsertTimesheetDaysMutationOptions = Apollo.BaseMutationOptions<UpsertTimesheetDaysMutation, UpsertTimesheetDaysMutationVariables>;

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.graphql
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.graphql
@@ -1,0 +1,36 @@
+query getTimesheetDaysForAssignedStaff(
+  $applicationId: Int!
+  $startDate: String!
+  $endDate: String!
+) {
+  getTimesheetDaysForAssignedStaff(
+    applicationId: $applicationId
+    startDate: $startDate
+    endDate: $endDate
+  ) {
+    data {
+      personId
+      firstName
+      lastName
+      timesheetDays {
+        id
+        date
+        hours
+      }
+    }
+  }
+}
+
+mutation upsertTimesheetDays($entries: [TimesheetDayUpsertInputDto!]!) {
+  upsertTimesheetDays(input: { entries: $entries }) {
+    data {
+      id
+      applicationId
+      personId
+      date
+      hours
+    }
+    message
+    success
+  }
+}

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.module.css
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.module.css
@@ -1,0 +1,89 @@
+.timesheetsTable {
+  table-layout: fixed;
+  overflow-x: auto;
+  border-collapse: collapse;
+  color: var(--typography-color-secondary);
+
+  thead {
+    position: sticky;
+    font-size: var(--typography-font-size-small-body);
+
+    th {
+      background: var(--theme-gray-20);
+      font-weight: var(--typography-font-weights-regular);
+      border: var(--layout-border-width-small) solid
+        var(--surface-color-border-default);
+      border-bottom: var(--layout-border-width-small) solid
+        var(--surface-color-border-medium);
+
+      padding: var(--layout-padding-xsmall) var(--layout-padding-small);
+      height: 64px;
+    }
+
+    th:first-child {
+      width: 40%;
+    }
+
+    th:not(:first-child) {
+      text-align: end;
+      min-width: 100px;
+    }
+
+    th:last-child {
+      text-align: center;
+      font-weight: var(--typography-font-weights-bold);
+    }
+  }
+
+  tbody {
+    font-size: var(--typography-font-size-small-body);
+
+    td {
+      padding: var(--layout-padding-xsmall) var(--layout-padding-small);
+      height: 64px;
+
+      input {
+        height: 40px;
+        width: 100%;
+        padding: var(--layout-padding-small) var(--layout-padding-medium);
+        font-size: var(--typography-font-size-large-body);
+        border-radius: var(--layout-margin-xsmall);
+        border: var(--layout-border-width-small) solid
+          var(--surface-color-border-default);
+        text-align: end;
+      }
+    }
+  }
+
+  tfoot {
+    font-size: var(--typography-font-size-large-body);
+    font-weight: var(--typography-font-weights-regular);
+
+    td {
+      padding: var(--layout-padding-small);
+      padding-right: var(--layout-padding-large);
+      padding-top: var(--layout-padding-large);
+
+      border: none;
+      background-color: transparent !important;
+    }
+
+    td:not(:first-child) {
+      text-align: end;
+    }
+  }
+}
+
+.projectCell {
+  font-size: var(--typography-font-size-small-body);
+  font-weight: var(--typography-font-weights-regular);
+}
+
+.weekRangeLabel {
+  font-size: var(--typography-font-size-large-body);
+  font-weight: var(--typography-font-weights-regular);
+}
+
+.highlight {
+  background-color: var(--theme-blue-30) !important;
+}

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/Timesheets.tsx
@@ -1,7 +1,239 @@
+import { useMemo, useState } from 'react';
+import { format, startOfWeek, endOfWeek, addWeeks, isThisWeek } from 'date-fns';
+import { useParams } from 'react-router-dom';
+import {
+  useGetTimesheetDaysForAssignedStaffQuery,
+  useUpsertTimesheetDaysMutation,
+} from './Timesheets.generated';
+import styles from './Timesheets.module.css';
+import { TimesheetsWeekSelection } from './components/TimesheetsWeekSelection';
+import { TimesheetsTableHead } from './components/TimesheetsTableHead';
+import { TimesheetsTableBody } from './components/TimesheetsTableBody';
+import { TimesheetsTableFooter } from './components/TimesheetsTableFooter';
+import { TimesheetsActions } from './components/TimesheetsActions';
+import {
+  NormalizedTimesheetData,
+  EditsData,
+  TimesheetChange,
+  StaffRow,
+} from './types';
+
+function getWeekRange(date: Date) {
+  const monday = startOfWeek(date, { weekStartsOn: 1 });
+  const sunday = endOfWeek(date, { weekStartsOn: 1 });
+  return { monday, sunday };
+}
+
+function formatHours(value: number | string): number {
+  return Number(parseFloat(String(value)).toFixed(2));
+}
+
+function getNumericCellValue(
+  normalizedData: NormalizedTimesheetData,
+  edits: EditsData,
+  personId: number,
+  dateStr: string,
+): number {
+  const currentValue = normalizedData[personId]?.[dateStr];
+  const editedValue = edits[personId]?.[dateStr];
+  return editedValue !== undefined
+    ? formatHours(editedValue)
+    : (currentValue?.hours ?? 0);
+}
+
+// Normalize API data for fast lookup
+function normalizeTimesheetData(
+  data: StaffRow[] | undefined,
+): NormalizedTimesheetData {
+  const normalized: NormalizedTimesheetData = {};
+
+  data?.forEach((person: StaffRow) => {
+    normalized[person.personId] = {};
+    person.timesheetDays.forEach((day) => {
+      const date = day.date.slice(0, 10);
+      normalized[person.personId][date] = {
+        hours: formatHours(day.hours ?? 0),
+        id: day.id,
+      };
+    });
+  });
+
+  return normalized;
+}
+
+// Denormalize data for API submission
+function denormalizeTimesheetData(
+  normalizedData: NormalizedTimesheetData,
+  edits: EditsData,
+  applicationId: number,
+): TimesheetChange[] {
+  const result: TimesheetChange[] = [];
+
+  Object.entries(edits).forEach(([personId, dateEdits]) => {
+    Object.entries(dateEdits).forEach(([date, value]) => {
+      const currentValue = normalizedData[Number(personId)]?.[date];
+      const newValue = value ? formatHours(value) : 0;
+
+      // Only include if the value has changed
+      if (currentValue?.hours !== newValue) {
+        result.push({
+          applicationId,
+          personId: Number(personId),
+          date,
+          hours: newValue,
+          timesheetDayId: currentValue?.id,
+        });
+      }
+    });
+  });
+
+  return result;
+}
+
 export const Timesheets = () => {
+  const [selectedDate, setSelectedDate] = useState<Date>(() => new Date());
+  const { monday: startDate, sunday: endDate } = useMemo(
+    () => getWeekRange(selectedDate),
+    [selectedDate],
+  );
+
+  const { id = '' } = useParams();
+  const applicationId = parseInt(id, 10);
+
+  const startDateStr = format(startDate, 'yyyy-MM-dd');
+  const endDateStr = format(endDate, 'yyyy-MM-dd');
+
+  const [edits, setEdits] = useState<EditsData>({});
+
+  const { data, refetch } = useGetTimesheetDaysForAssignedStaffQuery({
+    variables: {
+      applicationId,
+      startDate: startDateStr,
+      endDate: endDateStr,
+    },
+    notifyOnNetworkStatusChange: true,
+    onCompleted: () => {
+      setEdits({});
+    },
+  });
+
+  const [saveTimesheetDays, { loading: saveTimesheetDaysLoading }] =
+    useUpsertTimesheetDaysMutation();
+
+  const normalizedData = useMemo(
+    () =>
+      normalizeTimesheetData(
+        data?.getTimesheetDaysForAssignedStaff?.data ?? undefined,
+      ),
+    [data],
+  );
+
+  const staffRows: StaffRow[] =
+    (data?.getTimesheetDaysForAssignedStaff?.data as StaffRow[]) || [];
+
+  const weekDays: Date[] = useMemo(() => {
+    return Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(startDate);
+      d.setDate(d.getDate() + i);
+      return d;
+    });
+  }, [startDate]);
+
+  const handleWeekChange = (dir: number) => {
+    setSelectedDate((prev) => addWeeks(prev, dir));
+  };
+
+  const handleCellChange = (
+    personId: number,
+    dateStr: string,
+    value: string,
+  ) => {
+    // Only allow numbers with up to 2 decimal places
+    if (value === '' || /^\d*\.?\d{0,2}$/.test(value)) {
+      setEdits((prev) => ({
+        ...prev,
+        [personId]: {
+          ...prev[personId],
+          [dateStr]: value,
+        },
+      }));
+    }
+  };
+
+  const handleSave = async () => {
+    const changes = denormalizeTimesheetData(
+      normalizedData,
+      edits,
+      applicationId,
+    );
+    if (changes.length > 0) {
+      console.log('Timesheet changes to save:', changes);
+      await saveTimesheetDays({
+        variables: {
+          entries: changes,
+        },
+      });
+      refetch();
+    }
+  };
+
+  const totalHoursPerDay: number[] = weekDays.map((d) => {
+    let sum = 0;
+    staffRows.forEach((person) => {
+      const dateStr = format(d, 'yyyy-MM-dd');
+      const value = getNumericCellValue(
+        normalizedData,
+        edits,
+        person.personId,
+        dateStr,
+      );
+      if (!isNaN(value)) {
+        sum += value;
+      }
+    });
+    return formatHours(sum);
+  });
+
+  const totalForAllStaff: number = formatHours(
+    totalHoursPerDay.reduce((a, b) => a + b, 0),
+  );
+
+  const isCurrentWeek = isThisWeek(startDate, { weekStartsOn: 1 });
+
   return (
     <div>
-      <p>Timesheets Page</p>
+      <TimesheetsWeekSelection
+        startDate={startDate}
+        endDate={endDate}
+        isCurrentWeek={isCurrentWeek}
+        onWeekChange={handleWeekChange}
+        disabled={saveTimesheetDaysLoading}
+      />
+
+      <div>
+        <table className={`${styles.timesheetsTable}`}>
+          <TimesheetsTableHead weekDays={weekDays} />
+          <TimesheetsTableBody
+            staffRows={staffRows}
+            weekDays={weekDays}
+            normalizedData={normalizedData}
+            edits={edits}
+            onCellChange={handleCellChange}
+            disabled={saveTimesheetDaysLoading}
+            applicationId={applicationId}
+          />
+          <TimesheetsTableFooter
+            totalForAllStaff={totalForAllStaff}
+            totalHoursPerDay={totalHoursPerDay}
+          />
+        </table>
+      </div>
+
+      <TimesheetsActions
+        onSave={handleSave}
+        hasEdits={Object.keys(edits).length > 0}
+        disabled={saveTimesheetDaysLoading}
+      />
     </div>
   );
 };

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsActions.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsActions.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@cats/components/button/Button';
+import { UserPlus } from '@cats/components/common/icon';
+
+interface TimesheetsActionsProps {
+  onSave: () => void;
+  hasEdits: boolean;
+  disabled?: boolean;
+}
+
+export const TimesheetsActions = ({
+  onSave,
+  hasEdits,
+  disabled,
+}: TimesheetsActionsProps) => {
+  return (
+    <div className="d-flex gap-2 mt-4">
+      <Button variant="secondary" disabled={disabled}>
+        <UserPlus />
+        Add Assigned Staff
+      </Button>
+      <Button
+        variant="primary"
+        disabled={!hasEdits || disabled}
+        onClick={onSave}
+      >
+        Save
+      </Button>
+    </div>
+  );
+};

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsTableBody.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsTableBody.tsx
@@ -1,0 +1,86 @@
+import { format, isSameDay } from 'date-fns';
+import cx from 'classnames';
+import { XmarkIcon } from '@cats/components/common/icon';
+import styles from '../Timesheets.module.css';
+import { StaffRow } from '../types';
+
+interface TimesheetsTableBodyProps {
+  staffRows: StaffRow[];
+  weekDays: Date[];
+  normalizedData: any;
+  edits: any;
+  onCellChange: (personId: number, dateStr: string, value: string) => void;
+  disabled?: boolean;
+  applicationId: number;
+}
+
+export const TimesheetsTableBody = ({
+  staffRows,
+  weekDays,
+  normalizedData,
+  edits,
+  onCellChange,
+  disabled,
+  applicationId,
+}: TimesheetsTableBodyProps) => {
+  const today = new Date();
+
+  const getProjectInfo = (person: StaffRow) => (
+    <>
+      <div className="fw-bold">TODO: address</div>
+      <span>
+        {applicationId} • TODO: type • {person.firstName} {person.lastName}
+      </span>
+    </>
+  );
+
+  return (
+    <tbody>
+      {staffRows.map((person) => (
+        <tr key={person.personId}>
+          <td className={styles.projectCell}>{getProjectInfo(person)}</td>
+          {weekDays.map((day) => {
+            const dateStr = format(day, 'yyyy-MM-dd');
+            const currentValue = normalizedData[person.personId]?.[dateStr];
+            const editedValue = edits[person.personId]?.[dateStr];
+            const value =
+              editedValue !== undefined
+                ? editedValue
+                : (currentValue?.hours?.toFixed(2) ?? '');
+
+            return (
+              <td
+                key={dateStr}
+                className={cx({
+                  [styles.highlight]: isSameDay(day, today),
+                })}
+              >
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  pattern="\d*\.?\d{0,2}"
+                  value={value}
+                  disabled={disabled}
+                  onChange={(e) =>
+                    onCellChange(person.personId, dateStr, e.target.value)
+                  }
+                  onBlur={(e) => {
+                    if (e.target.value) {
+                      const num = parseFloat(e.target.value);
+                      if (isNaN(num)) return;
+
+                      onCellChange(person.personId, dateStr, num.toFixed(2));
+                    }
+                  }}
+                />
+              </td>
+            );
+          })}
+          <td className="text-center align-middle">
+            <XmarkIcon /> Remove
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  );
+};

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsTableFooter.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsTableFooter.tsx
@@ -1,0 +1,23 @@
+interface TimesheetsTableFooterProps {
+  totalForAllStaff: number;
+  totalHoursPerDay: number[];
+}
+
+export const TimesheetsTableFooter = ({
+  totalForAllStaff,
+  totalHoursPerDay,
+}: TimesheetsTableFooterProps) => {
+  return (
+    <tfoot>
+      <tr>
+        <td>
+          <span className="fw-bold">Total Hours:</span>{' '}
+          {totalForAllStaff.toFixed(2)}
+        </td>
+        {totalHoursPerDay.map((hours, index) => (
+          <td key={index}>{hours.toFixed(2)}</td>
+        ))}
+      </tr>
+    </tfoot>
+  );
+};

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsTableHead.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsTableHead.tsx
@@ -1,0 +1,34 @@
+import { format, isSameDay } from 'date-fns';
+import cx from 'classnames';
+import styles from '../Timesheets.module.css';
+
+interface TimesheetsTableHeadProps {
+  weekDays: Date[];
+}
+
+export const TimesheetsTableHead = ({ weekDays }: TimesheetsTableHeadProps) => {
+  const today = new Date();
+
+  return (
+    <thead>
+      <tr>
+        <th className={styles.projectCell}>
+          <div className="fw-bold">Project</div>
+          <span>Application ID • Application Type • Staff</span>
+        </th>
+        {weekDays.map((day, index) => (
+          <th
+            key={index}
+            className={cx({
+              [styles.highlight]: isSameDay(day, today),
+            })}
+          >
+            <div className="fw-bold">{format(day, 'EEEE')}</div>
+            <div>{format(day, 'd MMM')}</div>
+          </th>
+        ))}
+        <th>Actions</th>
+      </tr>
+    </thead>
+  );
+};

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsWeekSelection.tsx
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/components/TimesheetsWeekSelection.tsx
@@ -1,0 +1,59 @@
+import { format } from 'date-fns';
+import { Button } from '@cats/components/button/Button';
+import { ArrowLeft, ArrowRight } from '@cats/components/common/icon';
+import styles from '../Timesheets.module.css';
+
+interface TimesheetsWeekSelectionProps {
+  startDate: Date;
+  endDate: Date;
+  isCurrentWeek: boolean;
+  onWeekChange: (dir: number) => void;
+  disabled: boolean;
+}
+
+export const TimesheetsWeekSelection = ({
+  startDate,
+  endDate,
+  isCurrentWeek,
+  onWeekChange,
+  disabled,
+}: TimesheetsWeekSelectionProps) => {
+  return (
+    <div className="d-flex gap-4 mb-4 align-items-center">
+      <div>
+        <Button
+          variant="secondary"
+          onClick={() => onWeekChange(-1)}
+          aria-label="Previous week"
+          disabled={disabled}
+          style={{
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0,
+          }}
+        >
+          <ArrowLeft />
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => onWeekChange(1)}
+          aria-label="Next week"
+          disabled={disabled}
+          style={{
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+            borderLeft: 'none',
+          }}
+        >
+          <ArrowRight />
+        </Button>
+      </div>
+
+      <div className={styles.weekRangeLabel}>
+        {isCurrentWeek && <span className="fw-bold">This Week: </span>}
+        <span>
+          {format(startDate, 'd MMMM')} - {format(endDate, 'd MMMM yyyy')}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/types.ts
+++ b/cats-frontend/src/app/features/applications/application/applicationTabs/appTimesheets/types.ts
@@ -1,0 +1,29 @@
+import { GetTimesheetDaysForAssignedStaffQuery } from './Timesheets.generated';
+
+export type StaffRow = NonNullable<
+  GetTimesheetDaysForAssignedStaffQuery['getTimesheetDaysForAssignedStaff']['data']
+>[number];
+export type TimesheetDay = StaffRow['timesheetDays'][number];
+
+export type NormalizedTimesheetData = {
+  [personId: number]: {
+    [date: string]: {
+      hours: number;
+      id?: number;
+    };
+  };
+};
+
+export type EditsData = {
+  [personId: number]: {
+    [date: string]: string;
+  };
+};
+
+export type TimesheetChange = {
+  applicationId: number;
+  personId: number;
+  date: string;
+  hours: number;
+  timesheetDayId?: number;
+};

--- a/cats-frontend/src/generated/types.ts
+++ b/cats-frontend/src/generated/types.ts
@@ -659,7 +659,7 @@ export type QueryGetStaffsArgs = {
 
 
 export type QueryGetTimesheetDaysForAssignedStaffArgs = {
-  applicationId: Scalars['Float']['input'];
+  applicationId: Scalars['Int']['input'];
   endDate: Scalars['String']['input'];
   startDate: Scalars['String']['input'];
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

In this PR: 
- A table to manage application's timesheet records

Demo:
<img width="1314" alt="Screenshot 2025-06-13 at 8 17 22 PM" src="https://github.com/user-attachments/assets/88ed0351-b486-4246-b2e7-1da7a9869d10" />


Fixes [SRS-785](https://env-epd.atlassian.net/browse/SRS-785) partially

This that will be added in the next PR:

- Date picker component
- Ability to add staff (this button does nothing for now, users can add staff in the applications table for now)
- When changing weeks, set the `startDate` in query params to reflect the new week
- "Remove" button
- Missing application-related data

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test by navigating to `/applications/:id?tab=timesheets`

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged
