### PR TITLE
fix: Combine -seed and -init initContainers, only have one now, and updated seed logic in initDB.sh

### DIFF
--- a/backend/cats/initDB.sh
+++ b/backend/cats/initDB.sh
@@ -51,17 +51,17 @@ else
         echo "SEED_DATA_PATH is not set. Skipping seed data load."
     else
         # check if sites table has any rows
-        if [ "$(PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -t -c "SELECT count(*) FROM sites.sites;")" -gt 0 ]; then
+        if [ "$(PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -t -c "SELECT count(*) FROM cats.application;")" -gt 0 ]; then
             echo "Seed data already loaded. Skipping seed data load."
         else
-            echo "Seed data set, seed is enabled, and db is blank, disabling constraints."
+            echo "Seed data set, seed is enabled, and db is blank"
             # Disable constraints before seeding, if file exists
             if [ -f "/mnt/sql/disable_constraints.sql" ]; then
                 echo "Disabling constraints..."
                 PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -f "/mnt/sql/disable_constraints.sql"
             fi
 
-            echo "Seed data set, attempting to load."
+            echo "Seed data set, attempting to load with suppressed logs (this might take a while)."
             PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -q -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -f "$SEED_DATA_PATH" > /dev/null
             echo "Seed data successfully loaded."
 

--- a/backend/cats/initDB.sh
+++ b/backend/cats/initDB.sh
@@ -40,6 +40,40 @@ echo "init db complete"
 # run type orm migrations 
 npm run typeorm:run-migrations
 
+## TODO: Put seed data logic here.
+# check if seed is enabled or not SEED_ENABLED should be true
+if [ "$SEED_ENABLED" != "true" ]; then
+    echo "Seed data is not enabled. Skipping seed data load."
+else
+    echo "SEED DATA PATH :: $SEED_DATA_PATH"
+    # check if seed data path is set or not
+    if [ -z "$SEED_DATA_PATH" ]; then
+        echo "SEED_DATA_PATH is not set. Skipping seed data load."
+    else
+        # check if sites table has any rows
+        if [ "$(PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -t -c "SELECT count(*) FROM sites.sites;")" -gt 0 ]; then
+            echo "Seed data already loaded. Skipping seed data load."
+        else
+            echo "Seed data set, seed is enabled, and db is blank, disabling constraints."
+            # Disable constraints before seeding, if file exists
+            if [ -f "/mnt/sql/disable_constraints.sql" ]; then
+                echo "Disabling constraints..."
+                PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -f "/mnt/sql/disable_constraints.sql"
+            fi
+
+            echo "Seed data set, attempting to load."
+            PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -q -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -f "$SEED_DATA_PATH" > /dev/null
+            echo "Seed data successfully loaded."
+
+            # Enable constraints after seeding, if file exists
+            if [ -f "/mnt/sql/enable_constraints.sql" ]; then
+                echo "Enabling constraints..."
+                PGPASSWORD="$POSTGRES_ADMIN_PASSWORD" psql -h "$POSTGRESQL_HOST" -d "$POSTGRES_DATABASE" -U "$POSTGRES_ADMIN_USERNAME" -f "/mnt/sql/enable_constraints.sql"
+            fi
+        fi
+    fi
+fi
+
 npm run seed:service-types
 
 echo "migrations completed"

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -29,62 +29,12 @@ spec:
         - name: {{ include "backend.fullname" . }}-init
           image: "{{.Values.global.registry}}/{{.Values.global.repository}}/backend-migration:{{ .Values.global.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ default "Always" .Values.backend.imagePullPolicy }}
-          env:
-            - name: POSTGRES_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: password
-                  name: postgres-crunchy-pguser-{{ .Values.global.config.dbUser }}
-            - name: POSTGRES_DB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: user
-                  name: postgres-crunchy-pguser-{{ .Values.global.config.dbUser }}
-            - name: POSTGRES_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  key: dbname
-                  name: postgres-crunchy-pguser-{{ .Values.global.config.dbUser }}
-            - name: POSTGRES_DB_SCHEMA
-              value: {{ .Values.global.config.schemaName }}
-            - name: POSTGRESQL_HOST
-              valueFrom:
-                secretKeyRef:
-                  key: host
-                  name: postgres-crunchy-pguser-{{ .Values.global.config.dbUser }}
-            - name: POSTGRESQL_PORT
-              valueFrom:
-                secretKeyRef:
-                  key: port
-                  name: postgres-crunchy-pguser-{{ .Values.global.config.dbUser }}
-            - name: POSTGRES_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: password
-                  name: postgres-crunchy-pguser-postgres
-            - name: POSTGRES_ADMIN_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: user
-                  name: postgres-crunchy-pguser-postgres
-          resources: # this is optional
-            requests:
-              cpu: {{ .Values.backend.resources.requests.cpu }}
-              memory: {{ .Values.backend.resources.requests.memory }}
-        {{- if .Values.global.config.seed.enabled }}
-        - name: {{ include "backend.fullname" . }}-seed
-          image: "artifacts.developer.gov.bc.ca/github-docker-remote/bcgov/nr-containers/alpine:3.20" # here we just need a prebuilt image with psql and shell, just use postgres alpine image
-          imagePullPolicy: {{ default "Always" .Values.backend.imagePullPolicy }}
-          command: ["/bin/sh"]
-          args: ["-c", "sh /mnt/scripts/seed.sh"]
           volumeMounts:
             - mountPath: /mnt/sql
               name: seed-data-mount
             - mountPath: /mnt/scripts
               name: seed-data-scripts
           env:
-            - name: SEED_ENABLED
-              value: {{.Values.global.config.seed.enabled | quote}}
             - name: POSTGRES_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -122,6 +72,8 @@ spec:
                 secretKeyRef:
                   key: user
                   name: postgres-crunchy-pguser-postgres
+            - name: SEED_ENABLED
+              value: {{.Values.global.config.seed.enabled | quote}}
             - name: SEED_DATA_PATH
               value: "/mnt/sql/data_migration.sql"
             - name: VITE_CATS_CSSA_MANAGER_ROLE
@@ -130,7 +82,6 @@ spec:
             requests:
               cpu: {{ .Values.backend.resources.requests.cpu }}
               memory: {{ .Values.backend.resources.requests.memory }}
-        {{- end }}
       containers:
         - name: {{ include "backend.fullname" . }}
           {{- if .Values.backend.securityContext }}


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-992-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-992-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)