### PR TITLE
fix: the spelling mistake on the web apps favicon - "Site Remediaton Services" to Site Remediation Services

### DIFF
--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-web-root-config/src/index.ejs
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-web-root-config/src/index.ejs
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Site Remediaton Services</title>
+  <title>Site Remediation Services</title>
   <script src="/config/config.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/bpmn-js-properties-panel/dist/assets/properties-panel.css">
   <link rel="stylesheet" href="https://unpkg.com/bpmn-js-properties-panel/dist/assets/element-templates.css">


### PR DESCRIPTION
Fix the spelling mistake on the web apps favicon - "Site Remediaton Services" to Site Remediation Services

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-1095-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-1095-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)