### PR TITLE
SRS-1148: set Details as default tab in Application page

### DIFF
--- a/cats-frontend/src/app/features/applications/application/ApplicationTabsRouter.tsx
+++ b/cats-frontend/src/app/features/applications/application/ApplicationTabsRouter.tsx
@@ -12,8 +12,8 @@ import { Application } from './applicationTabs/application/Application';
 const ApplicationTabsRouter: React.FC = () => {
   return (
     <Routes>
-      <Route path="application" element={<Application />} />
       <Route path="details" element={<Details />} />
+      <Route path="application" element={<Application />} />
       <Route path="participants" element={<Participants />} />
       <Route path="timesheets" element={<Timesheets />} />
       <Route path="invoices" element={<Invoices />} />
@@ -21,7 +21,7 @@ const ApplicationTabsRouter: React.FC = () => {
       <Route path="associated-files" element={<AssociatedFiles />} />
       <Route path="housing" element={<Housing />} />
       {/* Redirect to the first tab by default */}
-      <Route path="*" element={<Navigate to="application" replace />} />
+      <Route path="*" element={<Navigate to="details" replace />} />
     </Routes>
   );
 };

--- a/cats-frontend/src/app/features/navigation/NavigationPillsConfig.tsx
+++ b/cats-frontend/src/app/features/navigation/NavigationPillsConfig.tsx
@@ -9,8 +9,8 @@ export type NavComponent = {
 
 // Navigation configuration for the pills - used by NavigationPills component
 export const navigationItems: Omit<NavComponent, 'component'>[] = [
-  { label: 'Application', value: 'application', path: 'application' },
   { label: 'Details', value: 'details', path: 'details' },
+  { label: 'Application', value: 'application', path: 'application' },
   { label: 'Participants', value: 'participants', path: 'participants' },
   { label: 'Timesheets', value: 'timesheets', path: 'timesheets' },
   { label: 'Invoices', value: 'invoices', path: 'invoices' },


### PR DESCRIPTION
Update CATS applications to have the application details as the default tab, vs the application forms.

<img width="772" height="261" alt="image" src="https://github.com/user-attachments/assets/049f806b-ca35-4ceb-b351-353a33935c2d" />
