### PR TITLE
forms-flow-documents image build changes

### DIFF
--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-documents/Dockerfile
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-documents/Dockerfile
@@ -1,5 +1,5 @@
 #Author: Kurian Benoy
-FROM python:3.9-slim-buster
+FROM --platform=linux/amd64 python:3.14-bookworm
 
 # set label for image
 LABEL Name="formsflow"
@@ -65,12 +65,11 @@ RUN mkdir -p /opt/chromedriver && \
     chmod +x /opt/chromedriver/chromedriver-linux64/chromedriver && \
     ln -fs /opt/chromedriver/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
 
-# Install Google Chrome
-RUN wget --no-verbose -O /tmp/chrome.deb https://formsflow-documentsapi.aot-technologies.com/google-chrome-stable_116.0.5845.140-1_amd64.deb &&\
-    apt-get update  && \
-    apt install -y /tmp/chrome.deb &&\
+# Install Google Chrome from local deb package
+COPY google-chrome-stable_116.0.5845.140-1_amd64.deb /tmp/chrome.deb
+RUN apt-get update && \
+    apt install -y /tmp/chrome.deb && \
     rm /tmp/chrome.deb
-
 
 # set display port to avoid crash
 ENV DISPLAY=:99
@@ -80,7 +79,7 @@ ENV PATH=/venv/bin:$PATH
 
 RUN : \
     && python3 -m venv /venv \
-    && pip install --upgrade pip \
+    && pip install --upgrade pip setuptools \
     && pip install -r requirements.txt 
 
 ADD . /forms-flow-documents/app

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-documents/docker-compose.yml
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-documents/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      args:
+        - ssh_prv_key=${SSH_PRV_KEY}
+        - ssh_pub_key=${SSH_PUB_KEY}
     restart: unless-stopped
     ports:
       - '5006:5006'

--- a/forms-flow-ai/forms-flow-ai-ee/forms-flow-documents/requirements.txt
+++ b/forms-flow-ai/forms-flow-ai-ee/forms-flow-documents/requirements.txt
@@ -19,7 +19,7 @@ attrs==23.1.0
 blinker==1.6.2
 cachelib==0.9.0
 certifi==2023.5.7
-cffi==1.15.1
+cffi==1.17.1
 charset-normalizer==3.1.0
 click==8.1.3
 cryptography==41.0.1
@@ -29,7 +29,7 @@ flask-jwt-oidc==0.3.0
 flask-marshmallow==0.15.0
 flask-restx==1.1.0
 formsflow-api-utils @ git+https://github.com/AOT-Technologies/forms-flow-ai.git@epd-5.2.2#subdirectory=forms-flow-api-utils
-gunicorn==20.1.0
+gunicorn==23.0.0
 h11==0.14.0
 h2==4.1.0
 hpack==4.0.0


### PR DESCRIPTION
Do not merge this.

Dockerfile is now using a local .deb package for installing Chrome since the download would often fail for me on rebuild. To test it, put `google-chrome-stable_116.0.5845.140-1_amd64.deb` in the same folder.