### PR TITLE
feat: SRS-1133: updating query to display previous assigned staff for newer applications

### DIFF
--- a/backend/cats/src/app/services/assignment/staffAssignment.service.ts
+++ b/backend/cats/src/app/services/assignment/staffAssignment.service.ts
@@ -146,7 +146,7 @@ p.id, p.first_name, p.middle_name, p.last_name
     p.first_name,
     p.middle_name,
     p.last_name,
-    sv.description,
+    COALESCE(sv.description, appast.service_name) AS description,
 	app.end_date,
 	app.id as appid,
     CASE 
@@ -173,12 +173,14 @@ INNER JOIN CATS.app_participant apt
     ON apt.application_id = app.id
 INNER JOIN CATS.person p 
     ON p.id = apt.person_id
-INNER JOIN CATS.app_service aps 
+LEFT OUTER JOIN CATS.app_service aps 
     ON aps.application_id = app.id
-INNER JOIN CATS.service sv 
+LEFT OUTER JOIN CATS.service sv 
 ON sv.id = aps.service_id
+LEFT OUTER JOIN cats.application_service_type appast
+ON appast.id = app.application_service_type_id
 WHERE app.site_id = ${siteId}
-  AND apt.participant_role_id =  ${roleId} AND SV.abbrev not in ('IR', 'FCR');`;
+  AND apt.participant_role_id =  ${roleId} AND (SV.abbrev not in ('IR', 'FCR') OR SV.abbrev is null );`;
   };
 
   getStaffWithCurrentFactorsQueryForApplicationServiceType = (


### PR DESCRIPTION
-- updating query to display previous assigned staff for newer applications

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-1248-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-1248-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)