### PR TITLE
fix: SRS-1470:Automate step to clear release left in a pending state

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -134,12 +134,18 @@ jobs:
       - if: steps.triggers.outputs.triggered == 'true'
         shell: bash
         run: |
+          set -euo pipefail
           RELEASE="${{ steps.vars.outputs.release }}"
           NS="${{ secrets.oc_namespace }}"
-          echo "Clearing pending Helm release secrets for ${RELEASE} in ${NS} (if any)"
-          oc delete secret -n "$NS" \
-            -l "owner=helm,name=${RELEASE},status in (pending-install,pending-upgrade,pending-rollback)" \
-            || true
+          LABEL="owner=helm,name=${RELEASE},status in (pending-install,pending-upgrade,pending-rollback)"
+          echo "Checking for pending Helm release secrets for ${RELEASE} in ${NS}"
+          COUNT=$(oc get secret -n "$NS" -l "$LABEL" --no-headers -o name | wc -l | tr -d ' \t')
+          if [[ "${COUNT}" -eq 0 ]]; then
+            echo "None found; continuing."
+            exit 0
+          fi
+          echo "Deleting ${COUNT} pending Helm release secret(s)"
+          oc delete secret -n "$NS" -l "$LABEL"
 
       # Only stop pre-existing deployments on PRs (status = pending-upgrade)
       - if: steps.triggers.outputs.triggered == 'true' && github.event_name == 'pull_request'

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -129,6 +129,18 @@ jobs:
           oc login --token=$OC_TEMP_TOKEN --server=${{ inputs.oc_server }}
           oc project ${{ secrets.oc_namespace }} # Safeguard!
 
+      # Drop stuck Helm revision secrets (e.g. after cancelled CI during atomic rollback).
+      # Scoped to this release only; does not remove deployed/superseded revisions.
+      - if: steps.triggers.outputs.triggered == 'true'
+        shell: bash
+        run: |
+          RELEASE="${{ steps.vars.outputs.release }}"
+          NS="${{ secrets.oc_namespace }}"
+          echo "Clearing pending Helm release secrets for ${RELEASE} in ${NS} (if any)"
+          oc delete secret -n "$NS" \
+            -l "owner=helm,name=${RELEASE},status in (pending-install,pending-upgrade,pending-rollback)" \
+            || true
+
       # Only stop pre-existing deployments on PRs (status = pending-upgrade)
       - if: steps.triggers.outputs.triggered == 'true' && github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
# Description

Helm releases could end up stuck in pending-install, pending-upgrade, or pending-rollback (for example when a GitHub Actions run is cancelled or stops during helm upgrade --atomic rollback). The next deploy then fails or hangs because Helm still sees an unfinished operation.

Manual recovery was to identify the release, list Helm release secrets, and oc delete secret only those with pending status labels for that release.

# Fix
/.github/workflows/.deployer.yml: After oc login / oc project, and before helm package / helm upgrade, add a step that:
Deletes Helm release Secrets in the deploy namespace with
owner=helm, name=<release>, and
status in (pending-install,pending-upgrade,pending-rollback)
(same scoped selector as the runbook).
Uses || true so the job does not fail when there is nothing to delete (normal case).
Release name and namespace match the rest of the job: steps.vars.outputs.release and secrets.oc_namespace.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-1251-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-1251-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)