### PR TITLE
feat: changes for allowing duplicate name while creating new person profile

### DIFF
--- a/backend/cats/src/app/services/people/people.service.spec.ts
+++ b/backend/cats/src/app/services/people/people.service.spec.ts
@@ -322,39 +322,6 @@ describe('PersonService', () => {
       expect(mockQueryBuilder.getOne).toHaveBeenCalled();
     });
 
-    it('should return existing person when duplicate found by name', async () => {
-      const createPersonInput = {
-        firstName: 'John',
-        lastName: 'Doe',
-        isTaxExempt: false,
-        isActive: true,
-        createdBy: 'system',
-        createdDatetime: new Date(),
-      } as CreatePerson;
-
-      const existingPerson = {
-        id: 1,
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john.doe@example.com',
-        personPermissions: [{ permissionId: 1 }, { permissionId: 2 }],
-      };
-
-      const mockQueryBuilder = {
-        andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(existingPerson),
-      };
-
-      (personRepository.createQueryBuilder as jest.Mock).mockReturnValue(
-        mockQueryBuilder,
-      );
-
-      const result = await personService.checkForDuplicate(createPersonInput);
-
-      expect(result).toEqual(existingPerson);
-      expect(mockQueryBuilder.getOne).toHaveBeenCalled();
-    });
-
     it('should return existing person when duplicate found by email', async () => {
       const createPersonInput = {
         firstName: 'Jane',
@@ -446,37 +413,6 @@ describe('PersonService', () => {
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
         'is_deleted is not true',
       );
-    });
-
-    it('should handle case-insensitive name matching', async () => {
-      const createPersonInput = {
-        firstName: 'JOHN',
-        lastName: 'DOE',
-        isTaxExempt: false,
-        isActive: true,
-        createdBy: 'system',
-        createdDatetime: new Date(),
-      } as CreatePerson;
-
-      const existingPerson = {
-        id: 1,
-        firstName: 'john',
-        lastName: 'doe',
-        personPermissions: [],
-      };
-
-      const mockQueryBuilder = {
-        andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(existingPerson),
-      };
-
-      (personRepository.createQueryBuilder as jest.Mock).mockReturnValue(
-        mockQueryBuilder,
-      );
-
-      const result = await personService.checkForDuplicate(createPersonInput);
-
-      expect(result).toEqual(existingPerson);
     });
   });
 });

--- a/backend/cats/src/app/services/people/people.service.ts
+++ b/backend/cats/src/app/services/people/people.service.ts
@@ -64,30 +64,34 @@ export class PersonService {
       query.andWhere('is_deleted is not true');
       query.andWhere(
         new Brackets((qb) => {
-          qb.where(
-            'LOWER(person.first_name) = LOWER(:firstName) AND LOWER(person.last_name) = LOWER(:lastName)',
-            {
-              firstName: input.firstName,
-              lastName: input.lastName,
-            },
-          );
-
           if (input.email) {
-            qb.andWhere('LOWER(person.email) = LOWER(:email)', {
+            qb.where('LOWER(person.email) = LOWER(:email)', {
               email: input.email,
             });
           }
 
           if (input.loginUserName) {
-            qb.andWhere(
-              'LOWER(person.login_user_name) = LOWER(:loginUserName)',
-              {
-                loginUserName: input.loginUserName,
-              },
-            );
+            if (input.email) {
+              qb.orWhere(
+                'LOWER(person.login_user_name) = LOWER(:loginUserName)',
+                { loginUserName: input.loginUserName },
+              );
+            } else {
+              qb.where(
+                'LOWER(person.login_user_name) = LOWER(:loginUserName)',
+                { loginUserName: input.loginUserName },
+              );
+            }
           }
         }),
       );
+
+      if (!input.email && !input.loginUserName) {
+        this.loggerSerivce.log(
+          'at service layer checkForDuplicate end - no email or loginUserName to check',
+        );
+        return null;
+      }
 
       const existingPerson = await query.getOne();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Updated code to allow duplicate name while creating new person profile

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually tested the changes for allowing duplicate names

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes



## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-1255-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-1255-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)