### PR TITLE
chore: SRS-1514 bcbox coms permissions

### DIFF
--- a/bcbox/Dockerfile
+++ b/bcbox/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=docker.io/node:20.9.0-alpine
 #
 # Build the frontend
 #
-FROM ${BASE_IMAGE} as frontend
+FROM ${BASE_IMAGE} AS frontend
 
 ARG APP_ROOT
 ENV NO_UPDATE_NOTIFIER=true
@@ -14,8 +14,7 @@ RUN mkdir -p /.npm
 RUN chown -R 1001:0 /.npm
 
 # Build Frontend
-COPY frontend ${APP_ROOT}
-RUN chown -R 1001:0 ${APP_ROOT}
+COPY --chown=1001:0 frontend ${APP_ROOT}
 USER 1001
 WORKDIR ${APP_ROOT}
 RUN npm ci && npm run build
@@ -31,21 +30,20 @@ ENV APP_PORT=8080 \
     NPM_CONFIG_CACHE=/tmp/.npm
 
 # NPM Permission Fix
-RUN mkdir -p /.npm /tmp/.npm
-RUN chown -R 1001:0 /.npm /tmp/.npm
-RUN chmod -R g+rwX /.npm /tmp/.npm
+RUN mkdir -p /tmp/.npm
+RUN chown -R 1001:0 /tmp/.npm
+RUN chmod -R g+rwX /tmp/.npm
 
 # Install File Structure
-COPY --from=frontend ${APP_ROOT}/dist ${APP_ROOT}/dist
+COPY --from=frontend --chown=1001:0 ${APP_ROOT}/dist ${APP_ROOT}/dist
 # COPY .git ${APP_ROOT}/.git # Temporarily commented out line due to OCP build failure. Unsure why it is necessary in the first place.
-COPY app ${APP_ROOT}
+COPY --chown=1001:0 app ${APP_ROOT}
 WORKDIR ${APP_ROOT}
 
 # Install Application
-RUN chown -R 1001:0 ${APP_ROOT}
 USER 1001
 WORKDIR ${APP_ROOT}/app
 RUN npm ci --omit=dev
 
 EXPOSE ${APP_PORT}
-CMD ["node", "./bin/www"]
+CMD ["npm", "run", "start"]

--- a/bcbox/Dockerfile
+++ b/bcbox/Dockerfile
@@ -27,11 +27,13 @@ FROM ${BASE_IMAGE}
 
 ARG APP_ROOT
 ENV APP_PORT=8080 \
-    NO_UPDATE_NOTIFIER=true
+    NO_UPDATE_NOTIFIER=true \
+    NPM_CONFIG_CACHE=/tmp/.npm
 
 # NPM Permission Fix
-RUN mkdir -p /.npm
-RUN chown -R 1001:0 /.npm
+RUN mkdir -p /.npm /tmp/.npm
+RUN chown -R 1001:0 /.npm /tmp/.npm
+RUN chmod -R g+rwX /.npm /tmp/.npm
 
 # Install File Structure
 COPY --from=frontend ${APP_ROOT}/dist ${APP_ROOT}/dist
@@ -46,4 +48,4 @@ WORKDIR ${APP_ROOT}/app
 RUN npm ci --omit=dev
 
 EXPOSE ${APP_PORT}
-CMD ["npm", "run", "start"]
+CMD ["node", "./bin/www"]

--- a/comsapi/Dockerfile
+++ b/comsapi/Dockerfile
@@ -2,12 +2,14 @@ FROM docker.io/node:18.18.2-alpine
 
 ARG APP_ROOT=/opt/app-root/src
 ENV APP_PORT=8080 \
-    NO_UPDATE_NOTIFIER=true
+    NO_UPDATE_NOTIFIER=true \
+    NPM_CONFIG_CACHE=/tmp/.npm
 WORKDIR ${APP_ROOT}
 
 # NPM Permission Fix
-RUN mkdir -p /.npm
-RUN chown -R 1001:0 /.npm
+RUN mkdir -p /.npm /tmp/.npm
+RUN chown -R 1001:0 /.npm /tmp/.npm
+RUN chmod -R g+rwX /.npm /tmp/.npm
 
 # Install Application
 COPY . ${APP_ROOT}
@@ -17,4 +19,4 @@ WORKDIR ${APP_ROOT}/app
 RUN npm ci --omit=dev
 
 EXPOSE ${APP_PORT}
-CMD ["npm", "run", "start"]
+CMD ["node", "./bin/www"]

--- a/comsapi/Dockerfile
+++ b/comsapi/Dockerfile
@@ -7,13 +7,12 @@ ENV APP_PORT=8080 \
 WORKDIR ${APP_ROOT}
 
 # NPM Permission Fix
-RUN mkdir -p /.npm /tmp/.npm
-RUN chown -R 1001:0 /.npm /tmp/.npm
-RUN chmod -R g+rwX /.npm /tmp/.npm
+RUN mkdir -p /tmp/.npm
+RUN chown -R 1001:0 /tmp/.npm
+RUN chmod -R g+rwX /tmp/.npm
 
 # Install Application
-COPY . ${APP_ROOT}
-RUN chown -R 1001:0 ${APP_ROOT}
+COPY --chown=1001:0 . ${APP_ROOT}
 USER 1001
 WORKDIR ${APP_ROOT}/app
 RUN npm ci --omit=dev


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

The goal of this is to fix a permissions issue with our BCBox and COMS service that is causing the pods to crash loop in the test and prod environments.

- Move the NPM cache directory to a place that won't have permissions issues.
- Remove the `RUN chown...` step for the app directory. This will speed up builds and reduce the size of the image because we will not have metadata changes for everything in `node_modules`.
- Add the `chown` flag to the `COPY` step so that permissions are correct without the above filesystem layering concern.
- For the COMSAPI, use node as the runtime instead of NPM. It's generally considered bad practice to use `npm run ...` in production. This is an upstream issue and relatively minor, but it should make this image more stable over time in case the underlying image's `npm` version drifts.
- I tried to add a precompile step to BCBox's image build to run directly with node, or running ts-node, but I ran into weird routing issues with the way the app is structured that I will look at solving iff we decide we need to maintain these services permanently

Currently this code is running and apparently stable in our test and prod environments. Once this is merged I will need to modify the BuildConfigs for these two services to use the `dev` ref again.

Fixes # 1514

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-1257-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-1257-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)