### PR TITLE
chore: SRS-1565: Add 2026 CATS service types, assignment factors, and staff permission mappings for Manage Staff dropdowns

### DIFF
--- a/backend/cats/src/seed/applicationServiceType.seed.spec.ts
+++ b/backend/cats/src/seed/applicationServiceType.seed.spec.ts
@@ -1,0 +1,146 @@
+import { ApplicationServiceType } from '../app/entities/applicationServiceType.entity';
+import { ParticipantRole } from '../app/entities/participantRole.entity';
+import { ServiceAssignmentFactor } from '../app/entities/serviceAssignmentFactor';
+import { StaffRoles } from '../app/services/assignment/staffRoles.enum';
+import { ApplicationServiceTypeSeeder } from './applicationServiceType.seed';
+import {
+  CASEWORKER_PERMISSIONS,
+  COMMON_PERMISSIONS,
+  MENTOR_PERMISSIONS,
+  SDM_PERMISSIONS,
+} from './permissions';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const legacyServiceTypes = require('./applicationServiceType.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const serviceTypes2026 = require('./applicationServiceType2026.json');
+
+describe('ApplicationServiceType seed data', () => {
+  it('contains 42 valid 2026 types alongside 36 unique legacy types', () => {
+    const allServiceTypes = [...legacyServiceTypes, ...serviceTypes2026];
+    const uniqueKeys = new Set(
+      allServiceTypes.map((item) => `${item.type}:${item.description}`),
+    );
+
+    expect(legacyServiceTypes).toHaveLength(36);
+    expect(serviceTypes2026).toHaveLength(42);
+    expect(allServiceTypes).toHaveLength(78);
+    expect(uniqueKeys.size).toBe(allServiceTypes.length);
+    expect(
+      serviceTypes2026.filter((item) => item.type === 'CSAP'),
+    ).toHaveLength(7);
+    expect(
+      serviceTypes2026.filter((item) => item.type === 'Non-CSAP'),
+    ).toHaveLength(35);
+
+    for (const item of serviceTypes2026) {
+      expect(item.description).toMatch(/^26-/);
+      expect(['CSAP', 'Non-CSAP']).toContain(item.type);
+      for (const factor of [item.CW, item.SDM, item.MNTR]) {
+        expect(Number.isFinite(factor)).toBe(true);
+        expect(factor).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it('maps every 2026 type to at least one staff permission', () => {
+    const permissionDefinitions = [
+      ...COMMON_PERMISSIONS,
+      ...SDM_PERMISSIONS,
+      ...CASEWORKER_PERMISSIONS,
+      ...MENTOR_PERMISSIONS,
+    ];
+    const mappedServiceTypes = new Set(
+      permissionDefinitions.flatMap((permission) =>
+        (permission.serviceTypesDetails ?? []).map(
+          (detail) => `${detail.serviceType}:${detail.applicationServiceDesc}`,
+        ),
+      ),
+    );
+
+    for (const item of serviceTypes2026) {
+      expect(mappedServiceTypes).toContain(`${item.type}:${item.description}`);
+    }
+  });
+
+  it('preserves the full statutory Site ID release labels', () => {
+    const descriptions = serviceTypes2026.map((item) => item.description);
+
+    expect(descriptions).toEqual(
+      expect.arrayContaining([
+        '26-Person Requests a Notice from a Director Stating the Director Does Not Require Site Investigation (Release under Scenario 1)',
+        '26-Person Requests a Notice from a Director Stating That the Site Would Not Present a Significant Threat or Risk If the Application Were Approved (Release under Scenario 2)',
+        '26-Person Requests a Notice from a Director Stating the Director Has Received a Remediation Plan Supporting Independent Remediation of the Site (Release under Scenario 3)',
+      ]),
+    );
+  });
+});
+
+describe('ApplicationServiceTypeSeeder', () => {
+  it('loads all seed records once and is idempotent', async () => {
+    const roles = {
+      [StaffRoles.CASE_WORKER]: { id: '1', abbrev: StaffRoles.CASE_WORKER },
+      [StaffRoles.SDM]: { id: '2', abbrev: StaffRoles.SDM },
+      [StaffRoles.MENTOR]: {
+        id: '3',
+        abbrev: StaffRoles.MENTOR,
+        description: 'Mentor',
+      },
+    };
+    const serviceTypes = new Map<string, ApplicationServiceType>();
+    const factors = new Set<string>();
+    let nextServiceTypeId = 1;
+
+    const manager = {
+      findOne: jest.fn(async (entity, options) => {
+        if (entity === ParticipantRole) {
+          if (options.where.description === 'Mentor') {
+            return roles[StaffRoles.MENTOR];
+          }
+          return roles[options.where.abbrev];
+        }
+
+        if (entity === ApplicationServiceType) {
+          const { serviceName, serviceType } = options.where;
+          return serviceTypes.get(`${serviceType}:${serviceName}`) ?? null;
+        }
+
+        if (entity === ServiceAssignmentFactor) {
+          const serviceTypeId = options.where.applicationServiceType.id;
+          const roleId = options.where.role.id;
+          return factors.has(`${serviceTypeId}:${roleId}`) ? { id: '1' } : null;
+        }
+
+        return null;
+      }),
+      save: jest.fn(async (entity) => {
+        if (entity instanceof ApplicationServiceType) {
+          entity.id = String(nextServiceTypeId++);
+          serviceTypes.set(
+            `${entity.serviceType}:${entity.serviceName}`,
+            entity,
+          );
+        }
+
+        if (entity instanceof ServiceAssignmentFactor) {
+          factors.add(`${entity.applicationServiceType.id}:${entity.role.id}`);
+        }
+
+        return entity;
+      }),
+      update: jest.fn(),
+    };
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await ApplicationServiceTypeSeeder(manager as never);
+
+    expect(serviceTypes.size).toBe(78);
+    expect(factors.size).toBe(234);
+
+    manager.save.mockClear();
+    await ApplicationServiceTypeSeeder(manager as never);
+
+    expect(manager.save).not.toHaveBeenCalled();
+    consoleLogSpy.mockRestore();
+  });
+});

--- a/backend/cats/src/seed/applicationServiceType.seed.ts
+++ b/backend/cats/src/seed/applicationServiceType.seed.ts
@@ -5,7 +5,10 @@ import { ServiceAssignmentFactor } from '../app/entities/serviceAssignmentFactor
 import { StaffRoles } from '../app/services/assignment/staffRoles.enum';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const serviceTypeJSON = require('./applicationServiceType.json');
+const legacyServiceTypes = require('./applicationServiceType.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const serviceTypes2026 = require('./applicationServiceType2026.json');
+const serviceTypes = [...legacyServiceTypes, ...serviceTypes2026];
 
 export const ApplicationServiceTypeSeeder = async (manager: EntityManager) => {
   console.log('ApplicationServiceTypeSeeder start');
@@ -52,7 +55,7 @@ export const ApplicationServiceTypeSeeder = async (manager: EntityManager) => {
     console.log('roles found', caseWorkerRole, sdmRole, mentorRole);
 
     if (caseWorkerRole && sdmRole && mentorRole) {
-      for (const item of serviceTypeJSON) {
+      for (const item of serviceTypes) {
         let serviceTypeItem = await manager.findOne(ApplicationServiceType, {
           where: {
             serviceName: item.description,

--- a/backend/cats/src/seed/applicationServiceType2026.json
+++ b/backend/cats/src/seed/applicationServiceType2026.json
@@ -1,0 +1,296 @@
+[
+  {
+    "type": "CSAP",
+    "description": "26-Approval in Principle",
+    "CW": 7.69,
+    "SDM": 6.96,
+    "MNTR": 3.48
+  },
+  {
+    "type": "CSAP",
+    "description": "26-Certificate of Compliance - Detailed Risk Assessment",
+    "CW": 4.75,
+    "SDM": 8.57,
+    "MNTR": 4.29
+  },
+  {
+    "type": "CSAP",
+    "description": "26-Certificate of Compliance - Numerical",
+    "CW": 23,
+    "SDM": 6.45,
+    "MNTR": 3.23
+  },
+  {
+    "type": "CSAP",
+    "description": "26-Certificate of Compliance - Screening Level Risk Assessment",
+    "CW": 0.25,
+    "SDM": 7.94,
+    "MNTR": 3.97
+  },
+  {
+    "type": "CSAP",
+    "description": "26-Final Determination under CSR 15(3)",
+    "CW": 2.13,
+    "SDM": 2.39,
+    "MNTR": 1.19
+  },
+  {
+    "type": "CSAP",
+    "description": "26-Preliminary Determination under CSR 15(3)",
+    "CW": 4.33,
+    "SDM": 5.69,
+    "MNTR": 2.84
+  },
+  {
+    "type": "CSAP",
+    "description": "26-CSAP - AP Statement or Report",
+    "CW": 5.27,
+    "SDM": 3.25,
+    "MNTR": 1.63
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Protocol 21 Water Use",
+    "CW": 8.74,
+    "SDM": 3.56,
+    "MNTR": 1.78
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Approval in Principle",
+    "CW": 19.63,
+    "SDM": 5.59,
+    "MNTR": 2.79
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Background Substance Concentrations: Protocol 4 Background Soil",
+    "CW": 13.34,
+    "SDM": 2.8,
+    "MNTR": 1.4
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Background Substance Concentrations: Protocol 9 Background Groundwater",
+    "CW": 9.83,
+    "SDM": 2.58,
+    "MNTR": 1.29
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Certificate of Compliance - Detailed Risk Assessment",
+    "CW": 48.38,
+    "SDM": 6.92,
+    "MNTR": 3.46
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Certificate of Compliance - Numerical",
+    "CW": 63.33,
+    "SDM": 7.27,
+    "MNTR": 3.63
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Certificate of Compliance - Screening Level Risk Assessment",
+    "CW": 0,
+    "SDM": 10,
+    "MNTR": 5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Confirmation of Remediation",
+    "CW": 60.5,
+    "SDM": 2,
+    "MNTR": 1
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Review of a Covenant Prior to Registering",
+    "CW": 14.5,
+    "SDM": 0.5,
+    "MNTR": 0.25
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Detailed Site Condition Report",
+    "CW": 19.63,
+    "SDM": 5.59,
+    "MNTR": 2.79
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Detailed Site Investigation",
+    "CW": 70.25,
+    "SDM": 7,
+    "MNTR": 3.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Determination of a Contaminated Site - Preliminary",
+    "CW": 7.25,
+    "SDM": 4.97,
+    "MNTR": 2.49
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Determination of a Contaminated Site - Final",
+    "CW": 0,
+    "SDM": 1.29,
+    "MNTR": 0.64
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Indemnification",
+    "CW": 60.5,
+    "SDM": 2,
+    "MNTR": 1
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Minor Contribution Status",
+    "CW": 7.25,
+    "SDM": 4.97,
+    "MNTR": 2.49
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Preliminary Site Investigation",
+    "CW": 22,
+    "SDM": 1.8,
+    "MNTR": 0.9
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Remediation Plan",
+    "CW": 70,
+    "SDM": 7,
+    "MNTR": 3.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Risk Assessment Not Included in a Remediation Plan",
+    "CW": 70.25,
+    "SDM": 7,
+    "MNTR": 3.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Site Specific Standards",
+    "CW": 7,
+    "SDM": 5,
+    "MNTR": 2.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Summary of Site Condition Report",
+    "CW": 3,
+    "SDM": 0.6,
+    "MNTR": 0.3
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Transfer Agreement",
+    "CW": 22,
+    "SDM": 1.8,
+    "MNTR": 0.9
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Voluntary Remediation Agreement",
+    "CW": 7,
+    "SDM": 5,
+    "MNTR": 2.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Person Requests a Notice from a Director Stating the Director Does Not Require Site Investigation (Release under Scenario 1)",
+    "CW": 3.18,
+    "SDM": 0.59,
+    "MNTR": 0.29
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Person Requests a Notice from a Director Stating That the Site Would Not Present a Significant Threat or Risk If the Application Were Approved (Release under Scenario 2)",
+    "CW": 12.62,
+    "SDM": 1.19,
+    "MNTR": 0.59
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Person Requests a Notice from a Director Stating the Director Has Received a Remediation Plan Supporting Independent Remediation of the Site (Release under Scenario 3)",
+    "CW": 22.06,
+    "SDM": 1.79,
+    "MNTR": 0.89
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Person Requests the Appointment of an Allocation Panel",
+    "CW": 7.25,
+    "SDM": 4.97,
+    "MNTR": 2.49
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Protocol 12 High Risk Reporting (Review of an Interim Report per Protocol 12 - Site Risk Classification)",
+    "CW": 7,
+    "SDM": 5,
+    "MNTR": 2.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-P12 - Reclassification",
+    "CW": 24.65,
+    "SDM": 1.85,
+    "MNTR": 0.93
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Person Requests Designation of an Area as an Environmental Management Area",
+    "CW": 48,
+    "SDM": 7,
+    "MNTR": 3.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Protocol 6 Pre-approval",
+    "CW": 7,
+    "SDM": 5,
+    "MNTR": 2.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Review of Interim Report for the Remediation of a Contaminated Site in Accordance with an Applicable Director's Protocol Made under Section 64(1)(d) of the Act",
+    "CW": 7,
+    "SDM": 5,
+    "MNTR": 2.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Request to Director: Review of Background Substance Concentrations for a Site under CSR s. 11, 17 or 18",
+    "CW": 7,
+    "SDM": 5,
+    "MNTR": 2.5
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Annual Update - Site ID",
+    "CW": 2.64,
+    "SDM": 0.46,
+    "MNTR": 0.23
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Annual Update - AiP Reporting",
+    "CW": 7.25,
+    "SDM": 4.97,
+    "MNTR": 2.49
+  },
+  {
+    "type": "Non-CSAP",
+    "description": "26-Annual Update - CoC Reporting",
+    "CW": 7.25,
+    "SDM": 4.97,
+    "MNTR": 2.49
+  }
+]

--- a/backend/cats/src/seed/permissions.ts
+++ b/backend/cats/src/seed/permissions.ts
@@ -1,4 +1,7 @@
-import { application } from 'express';
+const serviceTypeDetail = (
+  applicationServiceDesc: string,
+  serviceType: 'CSAP' | 'Non-CSAP',
+) => ({ applicationServiceDesc, serviceType });
 
 export const COMMON_PERMISSIONS = [
   {
@@ -8,6 +11,7 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Remediation plan with risk assessment',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Remediation Plan', 'Non-CSAP'),
     ],
   },
   {
@@ -17,6 +21,10 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Covenant',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Review of a Covenant Prior to Registering',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -26,6 +34,8 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Confirmation of Remediation',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Confirmation of Remediation', 'Non-CSAP'),
+      serviceTypeDetail('26-Indemnification', 'Non-CSAP'),
     ],
   },
   {
@@ -35,6 +45,8 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Authorizations - Monitoring Report',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Annual Update - AiP Reporting', 'Non-CSAP'),
+      serviceTypeDetail('26-Annual Update - CoC Reporting', 'Non-CSAP'),
     ],
   },
   {
@@ -62,6 +74,14 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Additional Services and Functions',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Site Specific Standards', 'Non-CSAP'),
+      serviceTypeDetail('26-Summary of Site Condition Report', 'Non-CSAP'),
+      serviceTypeDetail('26-Transfer Agreement', 'Non-CSAP'),
+      serviceTypeDetail('26-Voluntary Remediation Agreement', 'Non-CSAP'),
+      serviceTypeDetail(
+        '26-Person Requests Designation of an Area as an Environmental Management Area',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -80,6 +100,10 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Site ID Release (Scenario 1)',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Person Requests a Notice from a Director Stating the Director Does Not Require Site Investigation (Release under Scenario 1)',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -89,6 +113,10 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Site ID Release (Scenario 2)',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Person Requests a Notice from a Director Stating That the Site Would Not Present a Significant Threat or Risk If the Application Were Approved (Release under Scenario 2)',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -98,6 +126,10 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Site ID Release (Scenario 3)',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Person Requests a Notice from a Director Stating the Director Has Received a Remediation Plan Supporting Independent Remediation of the Site (Release under Scenario 3)',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -123,6 +155,18 @@ export const COMMON_PERMISSIONS = [
           'Detailed site investigation, Risk assessment with other services',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Approval in Principle', 'Non-CSAP'),
+      serviceTypeDetail(
+        '26-Certificate of Compliance - Detailed Risk Assessment',
+        'Non-CSAP',
+      ),
+      serviceTypeDetail('26-Detailed Site Condition Report', 'Non-CSAP'),
+      serviceTypeDetail('26-Detailed Site Investigation', 'Non-CSAP'),
+      serviceTypeDetail('26-Preliminary Site Investigation', 'Non-CSAP'),
+      serviceTypeDetail(
+        '26-Risk Assessment Not Included in a Remediation Plan',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -157,6 +201,19 @@ export const COMMON_PERMISSIONS = [
           'Preliminary Determination under CSR 15(3), with other reports',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Certificate of Compliance - Numerical', 'Non-CSAP'),
+      serviceTypeDetail(
+        '26-Certificate of Compliance - Screening Level Risk Assessment',
+        'Non-CSAP',
+      ),
+      serviceTypeDetail(
+        '26-Determination of a Contaminated Site - Preliminary',
+        'Non-CSAP',
+      ),
+      serviceTypeDetail(
+        '26-Determination of a Contaminated Site - Final',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -167,6 +224,10 @@ export const COMMON_PERMISSIONS = [
           'Background Substance Conc.: Protocol 4 Background Soil',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Background Substance Concentrations: Protocol 4 Background Soil',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -176,6 +237,7 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Protocol 6 Approval',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Protocol 6 Pre-approval', 'Non-CSAP'),
     ],
   },
   {
@@ -186,6 +248,10 @@ export const COMMON_PERMISSIONS = [
           'Background Substance Conc.: Protocol 9 Background Groundwater',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Background Substance Concentrations: Protocol 9 Background Groundwater',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -195,6 +261,7 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Protocol 21 Water Use',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Protocol 21 Water Use', 'Non-CSAP'),
     ],
   },
   {
@@ -204,6 +271,15 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Requests to Director',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Minor Contribution Status', 'Non-CSAP'),
+      serviceTypeDetail(
+        '26-Person Requests the Appointment of an Allocation Panel',
+        'Non-CSAP',
+      ),
+      serviceTypeDetail(
+        '26-Request to Director: Review of Background Substance Concentrations for a Site under CSR s. 11, 17 or 18',
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -214,6 +290,7 @@ export const COMMON_PERMISSIONS = [
           'P12 - Reclassification with or without additional services',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-P12 - Reclassification', 'Non-CSAP'),
     ],
   },
   {
@@ -223,6 +300,14 @@ export const COMMON_PERMISSIONS = [
         applicationServiceDesc: 'Reporting',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail(
+        '26-Protocol 12 High Risk Reporting (Review of an Interim Report per Protocol 12 - Site Risk Classification)',
+        'Non-CSAP',
+      ),
+      serviceTypeDetail(
+        "26-Review of Interim Report for the Remediation of a Contaminated Site in Accordance with an Applicable Director's Protocol Made under Section 64(1)(d) of the Act",
+        'Non-CSAP',
+      ),
     ],
   },
   {
@@ -250,6 +335,11 @@ export const SDM_PERMISSIONS = [
           'Certificate of Compliance - detailed risk assessment with or without other reports',
         serviceType: 'CSAP',
       },
+      serviceTypeDetail('26-Approval in Principle', 'CSAP'),
+      serviceTypeDetail(
+        '26-Certificate of Compliance - Detailed Risk Assessment',
+        'CSAP',
+      ),
     ],
   },
   {
@@ -279,6 +369,13 @@ export const SDM_PERMISSIONS = [
           'Preliminary Determination under CSR 15(3), with other reports',
         serviceType: 'CSAP',
       },
+      serviceTypeDetail('26-Certificate of Compliance - Numerical', 'CSAP'),
+      serviceTypeDetail(
+        '26-Certificate of Compliance - Screening Level Risk Assessment',
+        'CSAP',
+      ),
+      serviceTypeDetail('26-Final Determination under CSR 15(3)', 'CSAP'),
+      serviceTypeDetail('26-Preliminary Determination under CSR 15(3)', 'CSAP'),
     ],
   },
   {
@@ -288,6 +385,7 @@ export const SDM_PERMISSIONS = [
         applicationServiceDesc: 'Reporting',
         serviceType: 'CSAP',
       },
+      serviceTypeDetail('26-CSAP - AP Statement or Report', 'CSAP'),
     ],
   },
 ];
@@ -309,6 +407,7 @@ export const CASEWORKER_PERMISSIONS = [
         applicationServiceDesc: 'Site ID (Annual Update)',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Annual Update - Site ID', 'Non-CSAP'),
     ],
   },
 ];
@@ -327,6 +426,11 @@ export const MENTOR_PERMISSIONS = [
           'Certificate of Compliance - detailed risk assessment with or without other reports',
         serviceType: 'CSAP',
       },
+      serviceTypeDetail('26-Approval in Principle', 'CSAP'),
+      serviceTypeDetail(
+        '26-Certificate of Compliance - Detailed Risk Assessment',
+        'CSAP',
+      ),
     ],
   },
   {
@@ -356,6 +460,13 @@ export const MENTOR_PERMISSIONS = [
           'Preliminary Determination under CSR 15(3), with other reports',
         serviceType: 'CSAP',
       },
+      serviceTypeDetail('26-Certificate of Compliance - Numerical', 'CSAP'),
+      serviceTypeDetail(
+        '26-Certificate of Compliance - Screening Level Risk Assessment',
+        'CSAP',
+      ),
+      serviceTypeDetail('26-Final Determination under CSR 15(3)', 'CSAP'),
+      serviceTypeDetail('26-Preliminary Determination under CSR 15(3)', 'CSAP'),
     ],
   },
   {
@@ -374,6 +485,7 @@ export const MENTOR_PERMISSIONS = [
         applicationServiceDesc: 'Site ID (Annual Update)',
         serviceType: 'Non-CSAP',
       },
+      serviceTypeDetail('26-Annual Update - Site ID', 'Non-CSAP'),
     ],
   },
 ];


### PR DESCRIPTION
This PR adds 42 new `26- prefixed service types (7 CSAP and 35 Non-CSAP) while preserving the 36 legacy types. The existing idempotent seeder now loads the separate 2026 dataset, creates CW/SDM/Mentor assignment factors, and maps each type to an exact or closest matching staff permission.

Assumptions:

- Only application service types with numeric assignment hours are included.
- Billing tiers, Site Information Requests, unresolved-hour rows, and invoice integration are excluded.
- Legacy types remain selectable.
- Statutory service names are preserved with light formatting and typo cleanup.
- Existing permissions are reused based on the closest semantic match where no exact mapping exists.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-epd-digital-services-1278-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-epd-digital-services-1278-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-digital-services/actions/workflows/merge.yml)